### PR TITLE
AutoTests: локальный запуск API-тестов + ручной запуск CI

### DIFF
--- a/.github/skills/run-tests/SKILL.md
+++ b/.github/skills/run-tests/SKILL.md
@@ -41,7 +41,21 @@ npx playwright test
 
 ### Against a locally running API
 
-Set `BASE_URL` to point at the local instance before running:
+Start the local API first (see the [run-api](../run-api/SKILL.md) skill), then run the
+cross-platform npm script — it sets `BASE_URL=http://localhost:5000/api/` for you:
+
+```bash
+cd src/AutoTests
+npm run test:local
+```
+
+To run and open the HTML report afterwards:
+
+```bash
+npm run test:local:report
+```
+
+Alternatively, set `BASE_URL` manually before running:
 
 **bash / zsh**
 ```bash
@@ -54,18 +68,17 @@ $env:BASE_URL = "http://localhost:5000/api/"
 npx playwright test
 ```
 
-> Start the local API first — see the [run-api](../run-api/SKILL.md) skill.
-
 ## Useful Flags
 
 | Command | Purpose |
 |---|---|
-| `npx playwright test --project=chromium` | Run in Chromium only |
-| `npx playwright test --project=firefox` | Run in Firefox only |
-| `npx playwright test --project=webkit` | Run in WebKit only |
-| `npx playwright test --headed` | Run with visible browser windows |
+| `npm run test:local` | Run all tests against the local API (`http://localhost:5000/api/`) |
+| `npm run test:local:report` | Run against the local API, then open the HTML report |
 | `npx playwright test -g "create"` | Run tests matching a name pattern |
 | `npx playwright show-report` | Open the last HTML test report |
+
+> These are HTTP API tests, so the config uses a single `api` project — there are no
+> per-browser projects to select.
 
 ## Test Structure Overview
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,10 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+  workflow_dispatch:
+  # push:
+  #   branches: [ main, master ]
+  # pull_request:
+  #   branches: [ main, master ]
 jobs:
   test:
     timeout-minutes: 60

--- a/src/AddressBook.Api/AddressBook.Api.csproj
+++ b/src/AddressBook.Api/AddressBook.Api.csproj
@@ -11,14 +11,14 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Scalar.AspNetCore" Version="2.13.20" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.17" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AddressBook.Web/AddressBook.Web.csproj
+++ b/src/AddressBook.Web/AddressBook.Web.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="MudBlazor" Version="9.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="MudBlazor" Version="9.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoTests/package-lock.json
+++ b/src/AutoTests/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -657,9 +657,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1288,10 +1288,20 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/src/AutoTests/package-lock.json
+++ b/src/AutoTests/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "^9.12.0",
         "@playwright/test": "^1.48.0",
         "@types/node": "^22.7.5",
+        "cross-env": "^7.0.3",
         "eslint": "^9.12.0",
         "globals": "^15.11.0",
         "http-status-codes": "^2.3.0",
@@ -731,6 +732,25 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/src/AutoTests/package.json
+++ b/src/AutoTests/package.json
@@ -6,7 +6,9 @@
     "prettier:format": "prettier --write \"tests/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "prettier:check": "prettier --check \"tests/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "lint": "eslint tests",
-    "test": "npx playwright test"
+    "test": "npx playwright test",
+    "test:local": "cross-env BASE_URL=http://localhost:5000/api/ playwright test",
+    "test:local:report": "cross-env BASE_URL=http://localhost:5000/api/ playwright test && playwright show-report"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +18,7 @@
     "@eslint/js": "^9.12.0",
     "@playwright/test": "^1.48.0",
     "@types/node": "^22.7.5",
+    "cross-env": "^7.0.3",
     "eslint": "^9.12.0",
     "globals": "^15.11.0",
     "http-status-codes": "^2.3.0",

--- a/src/AutoTests/playwright.config.ts
+++ b/src/AutoTests/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
 
 /**
  * Read environment variables from file.
@@ -32,42 +32,11 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
-  /* Configure projects for major browsers */
+  /* Single project — these are HTTP API tests, so a browser engine is irrelevant. */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: 'api',
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
 
   /* Run your local dev server before starting the tests */


### PR DESCRIPTION
## Что сделано

### `src/AutoTests/package.json`
- Добавлена dev-зависимость `cross-env` (кросс-платформенная установка env-переменных — работает в PowerShell и bash).
- Добавлены npm-скрипты:
  - `test:local` → `cross-env BASE_URL=http://localhost:5000/api/ playwright test`
  - `test:local:report` → то же + открытие HTML-отчёта
- Существующий скрипт `test` (remote/Azure) оставлен без изменений.

### `src/AutoTests/playwright.config.ts`
- Три браузерных проекта заменены на один проект `api` (для HTTP API-тестов движок браузера не нужен) — прогон ускорился (10 тестов вместо 30).
- Удалён неиспользуемый импорт `devices`.

### `.github/skills/run-tests/SKILL.md`
- Обновлены секции «Running Tests» и «Useful Flags» под новый скрипт `test:local` и единый проект `api`.

### `.github/workflows/playwright.yml`
- Workflow переведён на ручной запуск: добавлен `workflow_dispatch`, триггеры `push` / `pull_request` временно закомментированы.

## Как запускать локально

```powershell
# терминал 1 — поднять API
cd src/AddressBook.Api ; dotnet run
# терминал 2 — прогнать тесты
cd src/AutoTests ; npm install ; npm run test:local
```

## Верификация

- `npm run lint` — без ошибок.
- `npm run test:local` против локального API — 9 passed, 1 failed.
- Единственное падение (`GET contacts by search term, verifying CORRECT names`) вызвано отсутствием сид-контактов «skr» в локальной БД (в Azure они есть) — зависимость теста от данных, не связанная с изменениями.

Refs #52