### PR TITLE
Fix data-dependent search test and default AutoTests to local API

### DIFF
--- a/.github/skills/run-tests/SKILL.md
+++ b/.github/skills/run-tests/SKILL.md
@@ -30,41 +30,47 @@ npx playwright install
 
 ## Running Tests
 
-### Against the remote Azure API (default)
-
-No configuration needed — the existing Azure URL is used as the fallback:
-
-```bash
-cd src/AutoTests
-npx playwright test
-```
-
-### Against a locally running API
+### Against a locally running API (default)
 
 Start the local API first (see the [run-api](../run-api/SKILL.md) skill), then run the
-cross-platform npm script — it sets `BASE_URL=http://localhost:5000/api/` for you:
+tests — the default `BASE_URL` fallback is `http://localhost:5000/api/`:
 
 ```bash
 cd src/AutoTests
-npm run test:local
+npm test
 ```
 
 To run and open the HTML report afterwards:
 
 ```bash
-npm run test:local:report
+npm run test:report
+```
+
+### Against the remote Azure API
+
+Use the cross-platform npm script — it sets the Azure `BASE_URL` for you:
+
+```bash
+cd src/AutoTests
+npm run test:remote
+```
+
+To run and open the HTML report afterwards:
+
+```bash
+npm run test:remote:report
 ```
 
 Alternatively, set `BASE_URL` manually before running:
 
 **bash / zsh**
 ```bash
-BASE_URL=http://localhost:5000/api/ npx playwright test
+BASE_URL=https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/ npx playwright test
 ```
 
 **PowerShell**
 ```powershell
-$env:BASE_URL = "http://localhost:5000/api/"
+$env:BASE_URL = "https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/"
 npx playwright test
 ```
 
@@ -72,8 +78,10 @@ npx playwright test
 
 | Command | Purpose |
 |---|---|
-| `npm run test:local` | Run all tests against the local API (`http://localhost:5000/api/`) |
-| `npm run test:local:report` | Run against the local API, then open the HTML report |
+| `npm test` | Run all tests against the local API (`http://localhost:5000/api/`) |
+| `npm run test:report` | Run against the local API, then open the HTML report |
+| `npm run test:remote` | Run all tests against the remote Azure API |
+| `npm run test:remote:report` | Run against the remote Azure API, then open the HTML report |
 | `npx playwright test -g "create"` | Run tests matching a name pattern |
 | `npx playwright show-report` | Open the last HTML test report |
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,22 @@
+{
+	"inputs": [
+		{
+			"id": "github_token",
+			"type": "promptString",
+			"description": "GitHub Personal Access Token",
+			"password": true
+		}
+	],
+	"servers": {
+		"github": {
+			"command": "npx",
+			"args": [
+				"-y",
+				"@modelcontextprotocol/server-github"
+			],
+			"env": {
+				"GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+			}
+		}
+	}
+}

--- a/docs/specs/AutoTests.md
+++ b/docs/specs/AutoTests.md
@@ -4,8 +4,8 @@
 
 `AutoTests` is a Playwright (TypeScript) end-to-end API test suite for the AddressBook solution.
 
-- Test target: configurable via `BASE_URL`, defaulting to the live Azure API at `https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/`
-- Local target: `http://localhost:5000/api/` via the `test:local` script (see [Running Tests](#running-tests))
+- Test target: configurable via `BASE_URL`, defaulting to the local API at `http://localhost:5000/api/`
+- Remote target: the live Azure API at `https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/` via the `test:remote` script or `BASE_URL` (see [Running Tests](#running-tests))
 - Test scope: API-level E2E scenarios for Contacts endpoints
 - Status code assertions: `http-status-codes` npm package (`StatusCodes` constants)
 - Execution model: a single `api` project (pure HTTP tests, no browser engine)
@@ -45,9 +45,10 @@ Source: `src/AutoTests/package.json`
 
 | Script | Command | Purpose |
 |---|---|---|
-| `test` | `npx playwright test` | Run against the default (Azure) `BASE_URL` |
-| `test:local` | `cross-env BASE_URL=http://localhost:5000/api/ playwright test` | Run against the local API |
-| `test:local:report` | same as `test:local`, then `playwright show-report` | Run locally and open the HTML report |
+| `test` | `npx playwright test` | Run against the local API (default `BASE_URL`) |
+| `test:report` | `npx playwright test && playwright show-report` | Run locally and open the HTML report |
+| `test:remote` | `cross-env BASE_URL=https://addressbook-api-...azurewebsites.net/api/ playwright test` | Run against the remote Azure API |
+| `test:remote:report` | same as `test:remote`, then `playwright show-report` | Run against Azure and open the HTML report |
 | `lint` | `eslint tests` | Lint the test sources |
 | `prettier:check` / `prettier:format` | Prettier check / write | Formatting |
 
@@ -59,7 +60,7 @@ Source: `src/AutoTests/tests/api-client.ts`
 
 `ApiClient` is implemented as a singleton wrapper over Playwright `APIRequestContext`.
 
-- Base URL: resolves from `process.env.BASE_URL` with fallback to `https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/`
+- Base URL: resolves from `process.env.BASE_URL` with fallback to `http://localhost:5000/api/`
 - Contacts path segment: `Contacts`
 - Assertion strategy:
   - Positive-path methods use in-method assertions (`expect.soft(...)`) and return typed payloads.

--- a/docs/specs/AutoTests.md
+++ b/docs/specs/AutoTests.md
@@ -4,10 +4,11 @@
 
 `AutoTests` is a Playwright (TypeScript) end-to-end API test suite for the AddressBook solution.
 
-- Test target: live Azure API at `https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/`
+- Test target: configurable via `BASE_URL`, defaulting to the live Azure API at `https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/`
+- Local target: `http://localhost:5000/api/` via the `test:local` script (see [Running Tests](#running-tests))
 - Test scope: API-level E2E scenarios for Contacts endpoints
 - Status code assertions: `http-status-codes` npm package (`StatusCodes` constants)
-- Cross-browser execution: Chromium, Firefox, WebKit
+- Execution model: a single `api` project (pure HTTP tests, no browser engine)
 
 ## Runtime and Tooling
 
@@ -15,6 +16,7 @@
 - Language: TypeScript
 - Linting: ESLint
 - Formatting: Prettier
+- Cross-platform env vars: `cross-env`
 - Package manager: npm
 
 ## Playwright Configuration
@@ -31,13 +33,23 @@ Source: `src/AutoTests/playwright.config.ts`
 | `reporter` | `html` |
 | `use.trace` | `on-first-retry` |
 
-### Browser Projects
+### Projects
 
-| Project Name | Device Profile |
+| Project Name | Description |
 |---|---|
-| `chromium` | `Desktop Chrome` |
-| `firefox` | `Desktop Firefox` |
-| `webkit` | `Desktop Safari` |
+| `api` | Single project for HTTP API tests; no browser engine is configured |
+
+## Running Tests
+
+Source: `src/AutoTests/package.json`
+
+| Script | Command | Purpose |
+|---|---|---|
+| `test` | `npx playwright test` | Run against the default (Azure) `BASE_URL` |
+| `test:local` | `cross-env BASE_URL=http://localhost:5000/api/ playwright test` | Run against the local API |
+| `test:local:report` | same as `test:local`, then `playwright show-report` | Run locally and open the HTML report |
+| `lint` | `eslint tests` | Lint the test sources |
+| `prettier:check` / `prettier:format` | Prettier check / write | Formatting |
 
 ## API Client Specification
 
@@ -118,10 +130,10 @@ Source: `src/AutoTests/tests/api-testing.spec.ts`
 | Test | Description |
 |---|---|
 | `get all contacts` | Fetches all contacts; verifies `rows.length > 0` and `rows.length === totalRows` |
-| `get all contacts by letters` | Searches with `skr`; verifies each returned name contains search term |
-| `GET contacts by search term, verifying CORRECT names` | Searches with `skr`; verifies exact expected contacts: Alex Skr (1972-07-14), Vera Skrynnik (1998-12-11), Skrynnik Vera (no birthday) |
+| `get all contacts by letters` | Searches with `skr`; verifies each returned name contains the search term |
+| `create contacts, verify search returns them, and delete` | Create → Verify → Delete: creates three contacts sharing a unique per-run search token (`Skr${Date.now()}`), verifies the search returns exactly those contacts, then deletes them in a `finally` block. Independent of seeded data. |
 
-Note in source code: a Russian comment explains both checks are intentionally kept to demonstrate two testing approaches.
+Note: both search tests are kept intentionally to demonstrate two testing approaches (source comment).
 
 ### GET /api/Contacts/{id}
 
@@ -186,7 +198,7 @@ All functional test cases must pass without critical defects.
 Source: `.github/workflows/playwright.yml`
 
 - Workflow name: `Playwright Tests`
-- Trigger: `push` and `pull_request` for `main` and `master`
+- Trigger: `workflow_dispatch` (manual). The `push` / `pull_request` triggers for `main` / `master` are present but commented out.
 - Runner: `ubuntu-latest`
 - Timeout: `60` minutes
 - Working directory for test commands: `src/AutoTests`

--- a/src/AutoTests/package.json
+++ b/src/AutoTests/package.json
@@ -7,8 +7,9 @@
     "prettier:check": "prettier --check \"tests/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "lint": "eslint tests",
     "test": "npx playwright test",
-    "test:local": "cross-env BASE_URL=http://localhost:5000/api/ playwright test",
-    "test:local:report": "cross-env BASE_URL=http://localhost:5000/api/ playwright test && playwright show-report"
+    "test:report": "npx playwright test && playwright show-report",
+    "test:remote": "cross-env BASE_URL=https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/ playwright test",
+    "test:remote:report": "cross-env BASE_URL=https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/ playwright test && playwright show-report"
   },
   "keywords": [],
   "author": "",

--- a/src/AutoTests/tests/api-client.ts
+++ b/src/AutoTests/tests/api-client.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { GetContactsResponse } from './dtos/GetContactsResponse';
 import { Contact } from './dtos/contact';
 
-const serviceURL = process.env.BASE_URL ?? 'https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/';
+const serviceURL = process.env.BASE_URL ?? 'http://localhost:5000/api/';
 const contactsPath = 'Contacts';
 
 export class ApiClient {

--- a/src/AutoTests/tests/api-testing.spec.ts
+++ b/src/AutoTests/tests/api-testing.spec.ts
@@ -28,31 +28,44 @@ test.describe('GET /api/Contacts', () => {
     expect.soft(contactsArray.length).toBe(contactsBody.totalRows);
   });
 
-  //хочу оставить обе проверки, чтобы показать два подхода к тестированию
-  test('GET contacts by search term, verifying CORRECT names', async ({ request }) => {
+  // Both search tests are kept intentionally to demonstrate two testing approaches
+  test('create contacts, verify search returns them, and delete', async ({ request }) => {
     const apiClient = ApiClient.getInstance(request);
-    const searchTerm = 'skr';
-    const contactsBody = await apiClient.getContactsByTerm(searchTerm);
-    const contactsArray = contactsBody.rows;
+    // Unique token keeps the test independent of seeded data and environment
+    const searchTerm = `Skr${Date.now()}`;
 
-    const EXPECTED_CORRECT_CONTACTS = [
-      new Contact('Alex', 'Skr', '1972-07-14'),
-      new Contact('Vera', 'Skrynnik', '1998-12-11'),
-      new Contact('Skrynnik', 'Vera'),
+    const expectedContacts = [
+      new Contact('Alex', searchTerm, '1972-07-14'),
+      new Contact('Vera', `${searchTerm}ynnik`, '1998-12-11'),
+      new Contact(`${searchTerm}ynnik`, 'Vera'),
     ];
 
-    expect.soft(contactsArray.length).toBe(EXPECTED_CORRECT_CONTACTS.length);
+    const createdIds: number[] = [];
+    try {
+      for (const contact of expectedContacts) {
+        createdIds.push(await apiClient.createContact(contact));
+      }
 
-    // Проверка 2: Каждый возвращенный контакт должен быть в списке ожидаемых
-    for (const actualContact of contactsArray) {
-      // Ищем соответствие в массиве ожидаемых контактов
-      const expectedMatch = EXPECTED_CORRECT_CONTACTS.find(
-        (expectedContact) =>
-          expectedContact.firstName === actualContact.firstName &&
-          expectedContact.lastName === actualContact.lastName,
-      );
+      const contactsBody = await apiClient.getContactsByTerm(searchTerm);
+      const contactsArray = contactsBody.rows;
 
-      expect.soft(expectedMatch).toBeDefined();
+      expect.soft(contactsArray.length).toBe(expectedContacts.length);
+      expect.soft(contactsBody.totalRows).toBe(expectedContacts.length);
+
+      // Every returned contact must be among the created ones
+      for (const actualContact of contactsArray) {
+        const expectedMatch = expectedContacts.find(
+          (expectedContact) =>
+            expectedContact.firstName === actualContact.firstName &&
+            expectedContact.lastName === actualContact.lastName,
+        );
+
+        expect.soft(expectedMatch).toBeDefined();
+      }
+    } finally {
+      for (const contactId of createdIds) {
+        await apiClient.deleteContactById(contactId);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Fixes the data-dependent AutoTests defect and makes the suite default to the local API.

Closes #54

## Changes

### Test fix (Create → Verify → Delete)
- Rewrote the failing `skr` search test so it seeds its own data using a unique per-run token (`Skr${Date.now()}`), verifies the search returns exactly those contacts, then deletes them in a `finally` block. No longer depends on pre-seeded data.

### Default to local API, remote opt-in
- Replaced the hardcoded Azure fallback in `api-client.ts` with `http://localhost:5000/api/`.
- `npm test` now runs against the local API by default.
- Added scripts: `test:report` (local + report), `test:remote` and `test:remote:report` (Azure via `cross-env BASE_URL`). Removed `test:local` / `test:local:report`.

### Cleanup & docs
- Translated all remaining Russian source comments to English.
- Updated `docs/specs/AutoTests.md` and the `run-tests` skill (local-by-default, remote opt-in, single `api` project, manual CI trigger).

## Verification
- ESLint: 0 errors.
- `npm test` (no `BASE_URL`) against the local API: **10 passed** (previously 9 passed / 1 failed).
