### PR TITLE
#63 [ApiTests][T4] schemas/contact.schema.ts — zod-контракты

### DIFF
--- a/docs/tasks/api-tests-framework-plan.md
+++ b/docs/tasks/api-tests-framework-plan.md
@@ -94,7 +94,7 @@ src/ApiTests/
 ### Фаза 1 — Инфраструктура
 
 - [x] **T3** ([#56](https://github.com/askrinnik/AddressBook2025/issues/56)) `config/env.ts` — zod-загрузчик окружения (`BASE_URL`, таймауты) + dotenv.
-- [ ] **T4** ([#63](https://github.com/askrinnik/AddressBook2025/issues/63)) `schemas/contact.schema.ts` — zod-схемы `Contact` / `ListResponse` / `ProblemDetails`.
+- [x] **T4** ([#63](https://github.com/askrinnik/AddressBook2025/issues/63)) `schemas/contact.schema.ts` — zod-схемы `Contact` / `ListResponse` / `ProblemDetails`.
 - [ ] **T5** ([#62](https://github.com/askrinnik/AddressBook2025/issues/62)) `clients/base-api-client.ts` + `contacts-client.ts` (5 методов, без ассертов, парсинг `Location` через `/\/Contacts\/(\d+)$/`).
 - [ ] **T6** ([#57](https://github.com/askrinnik/AddressBook2025/issues/57)) `models/problem-details.ts` — порт RFC7807-хелпера (`messagesFor`, `messages`, `hasErrors`).
 - [ ] **T7** ([#64](https://github.com/askrinnik/AddressBook2025/issues/64)) `data/contact.factory.ts` + `tokens.ts` — фабрики на faker + граничные варианты.

--- a/docs/tasks/issue-63-apitests-contract-schemas.md
+++ b/docs/tasks/issue-63-apitests-contract-schemas.md
@@ -1,0 +1,85 @@
+# Issue #63 — [ApiTests][T4] `schemas/contact.schema.ts` — zod-контракты
+
+> **Режим:** test-authoring / инфраструктура фреймворка (метки `api`, `testing`).
+> Production-код `AddressBook.Api` / `AddressBook.Web` **не трогаем**.
+> **Родительский план:** [docs/tasks/api-tests-framework-plan.md](api-tests-framework-plan.md) — задача **T4**.
+> **Зависит от:** T2 (`zod` в `main`). Не зависит от T3.
+
+## 1. Требование
+
+Описать zod-схемы ответов `AddressBook.Api` как единый источник контракта и TypeScript-типов:
+`ContactModel`, ответ списка контактов и RFC 7807 `ProblemDetails`. Из схем выводятся типы
+(`z.infer`), которые далее переиспользуют клиенты (T5), фикстуры/фабрики (T7–T8) и
+contract-тесты (T16).
+
+## 2. Факты об API (проверено по коду и текущим AutoTests)
+
+- Регистр JSON — **camelCase** (подтверждено использованием в `src/AutoTests`):
+  - `ContactModel`: `{ id: number, firstName: string, lastName: string, birthday: "yyyy-MM-dd" | null }`
+    (C# `record ContactModel(int Id, string FirstName, string LastName, DateOnly? Birthday)`).
+  - Список: `{ totalRows: number, rows: ContactModel[] }`
+    (C# `GetFilteredContactsResponse(int TotalRows, IReadOnlyCollection<ContactModel> Rows)`).
+- `ProblemDetails` (RFC 7807, `application/problem+json`), поля в lowercase:
+  `type?`, `title?`, `status?`, `detail?`, `instance?`, `errors?`. Для валидации `errors` —
+  карта `{ [field: string]: string[] }`. ASP.NET добавляет расширения (например `traceId`),
+  поэтому схема ProblemDetails **не строгая** (допускает доп. поля).
+
+## 3. Критерии приёмки
+
+| # | Критерий | Как проверяется |
+|---|----------|-----------------|
+| A1 | Схемы соответствуют реальным ответам API | Поднять API, `GET /api/Contacts` и `GET /api/Contacts/1` → `parse` проходит; невалидный `POST` → ответ проходит `ProblemDetailsSchema`. |
+| A2 | Экспортируются выведенные типы | `ContactModel`, `GetFilteredContactsResponse`, `ProblemDetails` через `z.infer`; `tsc --noEmit` чисто. |
+| A3 | Типы переиспользуемы | Экспорт схем и типов из одного модуля; именование согласовано с планом. |
+| A4 | lint + типы чистые | `eslint .` и `tsc --noEmit` без ошибок. |
+
+## 4. Затрагиваемые файлы
+
+| Файл | Изменение |
+|------|-----------|
+| `src/ApiTests/src/schemas/contact.schema.ts` | **Новый** — zod-схемы + выведенные типы. |
+| `docs/tasks/api-tests-framework-plan.md` | Отметить **T4** как выполненную (`[x]`). |
+
+## 5. Подход
+
+1. **`contact.schema.ts`:**
+   - `contactModelSchema` = `z.object({ id, firstName, lastName, birthday })`:
+     - `id`: `z.number().int()`.
+     - `firstName`/`lastName`: `z.string()`.
+     - `birthday`: `z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable()`.
+     - `.strict()` — контракт-тест обязан ловить дрейф (лишние поля вроде телефонов/OwnerId).
+   - `getFilteredContactsResponseSchema` = `z.object({ totalRows: z.number().int(), rows: z.array(contactModelSchema) }).strict()`.
+   - `problemDetailsSchema` = `z.object({ type?, title?, status?, detail?, instance?, errors? })`
+     **без** `.strict()` (RFC 7807 допускает расширения; ASP.NET добавляет `traceId`).
+     `errors`: `z.record(z.string(), z.array(z.string())).optional()`.
+   - Экспорт типов: `export type ContactModel = z.infer<typeof contactModelSchema>` и т.д.
+2. **Верификация против живого API** (см. критерий A1).
+
+### Решения
+
+- **`.strict()` для Contact/List, но не для ProblemDetails.** Строгость на моделях даёт ценность
+  contract-тестам (T16) — падаем при добавлении незадекларированного поля. ProblemDetails должен
+  быть терпимым, т.к. RFC 7807 и ASP.NET кладут доп. члены (`traceId`).
+- **`birthday` как строка-regex, а не `z.string().date()`** — явный формат `yyyy-MM-dd`,
+  не зависящий от версии zod, читаемое сообщение.
+
+## 6. Tests (Playwright E2E)
+
+Отдельных спеков в T4 **нет** — это модуль контракта без собственного API-поведения. Его
+корректность подтверждается компиляцией типов и проверкой `parse` против живых ответов API
+(критерий A1). Полное использование схем во всех ответах — задача **T16** (`contract/schema.spec.ts`).
+
+## 7. Вне объёма
+
+- `models/problem-details.ts` — хелпер RFC7807 (`messagesFor`/`messages`/`hasErrors`) — **T6**.
+- Клиенты (`base-api-client.ts`, `contacts-client.ts`) — **T5**.
+- Сами contract-тесты — **T16**.
+
+## 8. Верификация
+
+1. `npx tsc --noEmit` — без ошибок типов.
+2. `npm run lint` — без ошибок.
+3. Поднять API (`dotnet run --project src/AddressBook.Api`) и точечно прогнать `parse`:
+   - `GET /api/Contacts` → `getFilteredContactsResponseSchema.parse(body)` ок.
+   - `GET /api/Contacts/1` → `contactModelSchema.parse(body)` ок.
+   - невалидный `POST /api/Contacts` → `problemDetailsSchema.parse(body)` ок.

--- a/src/ApiTests/src/schemas/contact.schema.ts
+++ b/src/ApiTests/src/schemas/contact.schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+// Birthday is serialized by the API as an ISO date (yyyy-MM-dd) or null.
+export const birthdaySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Birthday must be a yyyy-MM-dd date')
+  .nullable();
+
+// Strict: contract tests must catch drift such as leaked phones or ownerId.
+export const contactModelSchema = z
+  .object({
+    id: z.number().int(),
+    firstName: z.string(),
+    lastName: z.string(),
+    birthday: birthdaySchema,
+  })
+  .strict();
+
+export const getFilteredContactsResponseSchema = z
+  .object({
+    totalRows: z.number().int(),
+    rows: z.array(contactModelSchema),
+  })
+  .strict();
+
+// RFC 7807 problem+json; not strict because ASP.NET adds extensions like traceId.
+export const problemDetailsSchema = z.object({
+  type: z.string().optional(),
+  title: z.string().optional(),
+  status: z.number().int().optional(),
+  detail: z.string().optional(),
+  instance: z.string().optional(),
+  errors: z.record(z.string(), z.array(z.string())).optional(),
+});
+
+export type ContactModel = z.infer<typeof contactModelSchema>;
+export type GetFilteredContactsResponse = z.infer<typeof getFilteredContactsResponseSchema>;
+export type ProblemDetails = z.infer<typeof problemDetailsSchema>;


### PR DESCRIPTION
Closes #63.

Adds zod contract schemas for the `AddressBook.Api` responses as the single source of truth for runtime validation and TypeScript types. Test-framework infrastructure only — no production code changed and no spec files added (contract tests land in T16).

## What it does
- Adds `src/ApiTests/src/schemas/contact.schema.ts`: `contactModelSchema`, `getFilteredContactsResponseSchema` (both `.strict()`), and a lenient `problemDetailsSchema`; exports the inferred `ContactModel`, `GetFilteredContactsResponse` and `ProblemDetails` types.

## Decisions worth noting
- JSON is camelCase (`totalRows`/`rows`, `firstName`/`lastName`), verified against live responses.
- `problemDetailsSchema` is intentionally non-strict: in Development the API adds RFC 7807 extensions (`traceId`, `StackTrace`) and the validation `errors` keys are PascalCase (`FirstName`/`LastName`).
- The contact/list schemas are strict so future contract tests catch drift (e.g. a leaked phone list or `ownerId`).
- `birthday` is validated as a nullable `yyyy-MM-dd` string via regex (version-independent, readable message).

## Verification
- `npx tsc --noEmit` → no type errors.
- `npm run lint` → clean.
- Ran `parse` against a live API for the list, a single contact, and an invalid `POST` problem-details response — all passed.