### PR TITLE
#60 [ApiTests][T8] fixtures/api.fixtures.ts — фикстуры с авто-очисткой

### DIFF
--- a/docs/tasks/api-tests-framework-plan.md
+++ b/docs/tasks/api-tests-framework-plan.md
@@ -98,7 +98,7 @@ src/ApiTests/
 - [x] **T5** ([#62](https://github.com/askrinnik/AddressBook2025/issues/62)) `clients/base-api-client.ts` + `contacts-client.ts` (5 методов, без ассертов, парсинг `Location` через `/\/Contacts\/(\d+)$/`).
 - [x] **T6** ([#57](https://github.com/askrinnik/AddressBook2025/issues/57)) `models/problem-details.ts` — порт RFC7807-хелпера (`messagesFor`, `messages`, `hasErrors`).
 - [x] **T7** ([#64](https://github.com/askrinnik/AddressBook2025/issues/64)) `data/contact.factory.ts` + `tokens.ts` — фабрики на faker + граничные варианты.
-- [ ] **T8** ([#60](https://github.com/askrinnik/AddressBook2025/issues/60)) `fixtures/api.fixtures.ts` — `test.extend` (client + factory + авто-очистка созданных контактов).
+- [x] **T8** ([#60](https://github.com/askrinnik/AddressBook2025/issues/60)) `fixtures/api.fixtures.ts` — `test.extend` (client + factory + авто-очистка созданных контактов).
 - [ ] **T9** ([#59](https://github.com/askrinnik/AddressBook2025/issues/59)) `utils/assertions.ts` — хелперы проверки схем и problem-details.
 
 ### Фаза 2 — Тесты

--- a/docs/tasks/issue-60-apitests-fixtures.md
+++ b/docs/tasks/issue-60-apitests-fixtures.md
@@ -1,0 +1,198 @@
+# Issue #60 — `[ApiTests][T8]` `fixtures/api.fixtures.ts` — фикстуры с авто-очисткой
+
+**Type:** test-authoring / инфраструктура фреймворка (метки `api`, `testing`) — задача **T8**
+из плана [`api-tests-framework-plan.md`](./api-tests-framework-plan.md).
+**Scope:** только `src/ApiTests/src/fixtures/**` + одна изолированная спека,
+подтверждающая, что фикстуры действительно чистят за собой. Никакого продакшн-кода
+(`AddressBook.Api`, `AddressBook.Contracts`, `AddressBook.Web`), никаких правок
+`src/AutoTests`.
+**Зависимости:** T5 (`BaseApiClient`, `ContactsClient`), T7 (`ContactFactory`).
+
+## 1. Требование (из issue)
+
+- `src/fixtures/api.fixtures.ts`:
+  - Фикстура `contactsClient` — создаётся per-test из `request`, без singleton.
+  - Фикстура `contactFactory`.
+  - Трекер созданных контактов + авто-удаление в teardown (`finally`-семантика).
+- Критерии из issue:
+  - Тесты не оставляют мусорных данных в БД.
+  - Устойчивость к `fullyParallel: true`.
+
+Позднее фикстуры будут переиспользованы во всех спеках эндпоинтов (T10–T15) и в
+contract-тестах (T16).
+
+## 2. Факты и опоры проектирования
+
+- Playwright `test.extend<F>({...})` даёт test-scoped фикстуры: setup выполняется до
+  теста, teardown — после (в том числе при падении теста). Компонуемость через
+  «request-fixture» в аргументах фабрики.
+- `fullyParallel: true` (см. [`playwright.config.ts`](../../src/ApiTests/playwright.config.ts))
+  распределяет тесты по воркерам-процессам. Каждый воркер — свой `RUN_TOKEN` из T7,
+  свой module-state. Test-scoped фикстура создаётся на каждый тест внутри воркера — нет
+  общего состояния между тестами.
+- `ContactsClient` (T5) не имеет ассертов и возвращает сырой `ApiResponse`; для авто-очистки
+  нужно перехватывать успешное `create` и запоминать полученный `id`.
+- `ContactFactory` (T7) — класс со static-методами; логично отдавать «как есть» через
+  фикстуру, чтобы тесты писали `contactFactory.validContact(...)` без прямого импорта
+  класса (единая точка входа через `import { test, expect } from '../../src/fixtures/api.fixtures.js'`).
+- `DELETE /api/Contacts/{id}` возвращает `204` при удачном удалении и `404`, если контакта
+  уже нет (см. §3 плана). Teardown должен молча пережёвывать `404` — тест мог удалить
+  контакт сам (например, в `delete.spec.ts` из T14).
+
+## 3. Acceptance criteria
+
+| # | Критерий | Как проверим |
+|---|----------|--------------|
+| AC1 | Экспорт `test` и `expect` из `api.fixtures.ts`; фикстуры типизированы и не тянут singleton (`grep` по `singleton|getInstance|static\s+instance` в модуле ничего не даёт). | Code review + импорт из спеки. |
+| AC2 | `contactsClient` — фикстура test-scoped, инстанс создаётся per-test через `new ContactsClient(new BaseApiClient(request))`. Разные тесты получают **разные** инстансы (`===` не совпадает). | Спека: два теста сохраняют ссылку на клиента через worker-level fixture / module-state и проверяют `!==`. Достаточно кросс-тестовой проверки в `describe.serial`. |
+| AC3 | `contactFactory` — фикстура, возвращающая `ContactFactory` (сам класс), тесты пишут `contactFactory.validContact(...)`. | Спека: `expect(contactFactory).toBe(ContactFactory)`; вызов `contactFactory.validContact()` возвращает валидный объект. |
+| AC4 | Создание контакта через `contactsClient.create(...)` **автоматически** регистрирует `id` в трекере. После teardown контакт в БД отсутствует. | Спека `describe.serial`: тест A создаёт контакт через фикстуру и «прокидывает» его `id` наверх; тест B — с сырым клиентом (`new ContactsClient(...)`) проверяет `GET /api/Contacts/{id}` → `404`. |
+| AC5 | Teardown устойчив к идемпотентности: если тест сам удалил контакт, повторное `DELETE` в teardown не роняет прогон (проглатываем `404`/сетевые сбои, best-effort). | Спека: тест создаёт контакт через фикстуру, потом сам его удаляет; проверяем, что тест завершается success, teardown не бросает. |
+| AC6 | Teardown продолжает удалять остальные контакты, даже если удаление одного упало (перехватываем ошибку по элементу). | Юнит-подобная часть спеки: намеренно ломаем удаление одного из трёх созданных контактов (например, регистрируем «фейковый» id через прямой доступ к трекеру, если такой есть). Если механизм регистрации не публичен — покрываем это код-ревью и явно оставляем комментарий в фикстуре. |
+| AC7 | Устойчивость к `fullyParallel: true`: в спеке несколько тестов подряд создают контакты через фикстуру, никаких коллизий и «утечек» между воркерами не происходит (проверяется тем, что кросс-worker обмена через `contactsClient` нет, module-state воркер-локален). | Прогон всей спеки при `fullyParallel: true` — тесты зелёные, никакой контакт не «перетекает». |
+| AC8 | `npm run lint` + `npx tsc --noEmit` в `src/ApiTests` — чисто. | Прогон в шаге 8. |
+| AC9 | Чек-бокс **T8** в [`docs/tasks/api-tests-framework-plan.md`](./api-tests-framework-plan.md) переведён в `[x]`. | Diff файла плана. |
+
+## 4. Затрагиваемые файлы
+
+| Файл | Изменение |
+|------|-----------|
+| `src/ApiTests/src/fixtures/api.fixtures.ts` | **Новый** — `test.extend`, три фикстуры + teardown. |
+| `src/ApiTests/src/fixtures/.gitkeep` | **Удалить**. |
+| `src/ApiTests/tests/fixtures/api.fixtures.spec.ts` | **Новый** — спека, покрывающая AC1–AC7. |
+| `docs/tasks/api-tests-framework-plan.md` | Отметить **T8** как `[x]`. |
+
+## 5. Дизайн
+
+### 5.1. Публичный API `api.fixtures.ts`
+
+```ts
+import { test as base, expect } from '@playwright/test';
+import { BaseApiClient } from '../clients/base-api-client.js';
+import { ContactsClient } from '../clients/contacts-client.js';
+import { ContactFactory } from '../data/contact.factory.js';
+
+export interface CreatedContactTracker {
+  register(id: number): void;
+  readonly ids: readonly number[];
+}
+
+export interface ApiFixtures {
+  contactsClient: ContactsClient;
+  contactFactory: typeof ContactFactory;
+  createdContacts: CreatedContactTracker;
+}
+
+export const test: TestType<ApiFixtures & ...>;
+export { expect };
+```
+
+Ключевые решения:
+
+- **Три фикстуры, все test-scoped.** `contactFactory` — константа-ссылка на класс, никакой
+  инстанс не строится. `createdContacts` — свежий трекер per-test. `contactsClient` — свежий
+  инстанс `ContactsClient` per-test, обёрнутый так, что `create` подмешивает регистрацию `id`
+  в трекер.
+- **`createdContacts` вынесена как отдельная фикстура**, чтобы тесты могли явно
+  регистрировать «свои» id (например, если контакт создавался через побочный путь, а не
+  через `contactsClient.create`). Это же даёт AC5/AC6 явную точку контроля.
+- **Обёртка над `create` через приватный подкласс**, а не `Proxy` — читабельнее и
+  сохраняет типы:
+  ```ts
+  class TrackedContactsClient extends ContactsClient {
+    constructor(base: BaseApiClient, private readonly tracker: CreatedContactTracker) {
+      super(base);
+    }
+    async create(cmd: CreateContactCommand): Promise<CreateContactResult> {
+      const result = await super.create(cmd);
+      if (typeof result.id === 'number') this.tracker.register(result.id);
+      return result;
+    }
+  }
+  ```
+  Класс модуль-приватный, наружу отдаётся как `ContactsClient` — тесты видят обычный тип.
+- **Teardown — best-effort в `try/catch`.** Каждое `DELETE` в отдельном `try/catch`; провал
+  одного не мешает остальным. `404` — «ничего страшного, тест сам почистил». Прочие ошибки
+  логируем `console.warn` (без падения теста): teardown не должен «маскировать» реальный
+  провал теста.
+- **Никаких `expect` в фикстуре.** Все ассерты живут в тестах.
+- **`export { expect }` из того же модуля.** Тесты пишут
+  `import { test, expect } from '../../src/fixtures/api.fixtures.js'` — одна точка входа.
+
+### 5.2. Спека `tests/fixtures/api.fixtures.spec.ts`
+
+Структура:
+
+1. **`test.describe('api fixtures — smoke')`** — быстрые проверки без хитрой оркестрации.
+   - `contactFactory` — это `ContactFactory` (`toBe`), `contactFactory.validContact()`
+     возвращает валидный объект.
+   - `contactsClient` — инстанс `ContactsClient`; успешный `create` увеличивает
+     `createdContacts.ids.length` на 1.
+
+2. **`test.describe.serial('api fixtures — auto cleanup')`** — доказывает, что teardown
+   удаляет контакты (AC4, AC7).
+   - Тест A: создать контакт через фикстуру, дописать `res.id` в `describe`-локальный
+     массив `createdIds`, `expect(...).toBe(StatusCodes.CREATED)`.
+   - Тест B: для каждого id из массива создать **сырой** `ContactsClient` (не через
+     фикстуру) и вызвать `getById(id)` → `404`.
+   - `describe.serial` гарантирует порядок и не мешает `fullyParallel: true` для остальных
+     файлов.
+
+3. **`test('teardown tolerates a contact already deleted in-test')`** — AC5.
+   - Создать контакт через фикстуру, тут же `contactsClient.delete(id)` → `204`.
+   - Тест завершается success. (Если teardown ронёт, тест будет помечен failed —
+     это и есть проверка.)
+
+4. **`test('teardown continues after a failed delete')`** — AC6.
+   - Регистрируем в трекере «недостижимый» id (например, `Number.MAX_SAFE_INTEGER`)
+     через `createdContacts.register(...)`, плюс создаём один реальный контакт через
+     фикстуру.
+   - Тест успешен. После teardown реальный контакт удалён (проверяем в
+     `describe.serial`-паре: следующий тест смотрит `GET /{id}` → `404`).
+
+Спека соответствует `playwright-conventions`: маршрутизация через `ContactsClient`,
+никаких `expect` внутри клиента/фикстуры, независимые шаги, Create → Verify → Delete
+(здесь Delete — руками фикстуры).
+
+### 5.3. Что осталось за кадром намеренно
+
+- **Миграцию существующих спек на фикстуры не делаем в этом таске.** `contact.factory.spec.ts`
+  (T7) и `problem-details.spec.ts` (T6) продолжают строить клиент вручную. Переход на
+  фикстуры — часть подготовки к T10+ или отдельная уборка.
+- **Worker-scoped фикстур нет.** Всё test-scoped: проще рассуждать, меньше нюансов
+  с `fullyParallel`.
+- **`request`-fixture не переопределяем**: `contactsClient` зависит от встроенной
+  `request`, никаких `test.use({ ... })` мы здесь не трогаем.
+
+## 6. Тесты в этой задаче
+
+Одна спека (`tests/fixtures/api.fixtures.spec.ts`), четыре-пять `test(...)` в трёх
+`describe` (один — `serial`). Всё в режиме `fullyParallel` — сериализация ограничена только
+парой Create-then-Verify для проверки teardown, что и требуется по AC.
+
+## 7. План работ
+
+1. Создать `src/fixtures/api.fixtures.ts` по §5.1.
+2. Удалить `src/fixtures/.gitkeep`.
+3. Создать `tests/fixtures/api.fixtures.spec.ts` по §5.2.
+4. `npm run lint` в `src/ApiTests` → без ошибок.
+5. `npx tsc --noEmit` в `src/ApiTests` → без ошибок.
+6. `npx playwright test tests/fixtures/api.fixtures.spec.ts` при поднятом API → зелёная.
+7. Отметить чек-бокс **T8** как `[x]` в `docs/tasks/api-tests-framework-plan.md`.
+
+## 8. Verification (шаг 8 промпта, режим test-authoring)
+
+- `npm run lint` в `src/ApiTests` → 0 ошибок.
+- `npx tsc --noEmit` в `src/ApiTests` → 0 ошибок.
+- `npx playwright test tests/fixtures/api.fixtures.spec.ts` — все кейсы зелёные,
+  включая проверку «контакт удалён после teardown».
+- `dotnet build src/AddressBook.sln` (§7 промпта) → без новых предупреждений
+  (C#-код не трогаем).
+
+## 9. Out of scope / follow-ups
+
+- Не удаляем и не переписываем `src/AutoTests` — старая суита живёт до T19.
+- Не мигрируем `contact.factory.spec.ts` / `problem-details.spec.ts` на фикстуры — это
+  сделаем при написании реальных спек в T10+ (или отдельным cleanup-таском).
+- Не вводим worker-scoped ресурсы: для нашей нагрузки test-scoped фикстур достаточно.
+- README `src/ApiTests` (T17 / #71) — не сюда, но зафиксируем использование фикстур там же.

--- a/src/ApiTests/src/fixtures/api.fixtures.ts
+++ b/src/ApiTests/src/fixtures/api.fixtures.ts
@@ -1,0 +1,86 @@
+import { test as base, expect } from '@playwright/test';
+import { BaseApiClient } from '../clients/base-api-client.js';
+import {
+  ContactsClient,
+  type CreateContactCommand,
+  type CreateContactResult,
+} from '../clients/contacts-client.js';
+import { ContactFactory } from '../data/contact.factory.js';
+
+export interface CreatedContactTracker {
+  register(id: number): void;
+  readonly ids: readonly number[];
+}
+
+export interface ApiFixtures {
+  contactsClient: ContactsClient;
+  contactFactory: typeof ContactFactory;
+  createdContacts: CreatedContactTracker;
+}
+
+class InMemoryCreatedContactTracker implements CreatedContactTracker {
+  private readonly registered = new Set<number>();
+
+  register(id: number): void {
+    this.registered.add(id);
+  }
+
+  get ids(): readonly number[] {
+    return [...this.registered];
+  }
+}
+
+// Extends ContactsClient so tests see the same public surface; wraps `create` to auto-register.
+class TrackedContactsClient extends ContactsClient {
+  constructor(
+    baseClient: BaseApiClient,
+    private readonly tracker: CreatedContactTracker,
+  ) {
+    super(baseClient);
+  }
+
+  async create(command: CreateContactCommand): Promise<CreateContactResult> {
+    const result = await super.create(command);
+    if (typeof result.id === 'number') this.tracker.register(result.id);
+    return result;
+  }
+}
+
+export const test = base.extend<ApiFixtures>({
+  // Playwright inspects the source to detect fixture dependencies, so the empty destructuring
+  // pattern is required for zero-dependency fixtures.
+  // eslint-disable-next-line no-empty-pattern
+  contactFactory: async ({}, use) => {
+    await use(ContactFactory);
+  },
+
+  // eslint-disable-next-line no-empty-pattern
+  createdContacts: async ({}, use) => {
+    await use(new InMemoryCreatedContactTracker());
+  },
+
+  contactsClient: async ({ request, createdContacts }, use) => {
+    const rawBase = new BaseApiClient(request);
+    const client = new TrackedContactsClient(rawBase, createdContacts);
+
+    await use(client);
+
+    // Best-effort teardown: try to delete every tracked id; swallow 404 (already gone),
+    // log anything else so an unexpected cleanup failure surfaces without failing the test.
+    const cleanup = new ContactsClient(rawBase);
+    for (const id of createdContacts.ids) {
+      try {
+        const response = await cleanup.delete(id);
+        if (response.status !== 204 && response.status !== 404) {
+          console.warn(
+            `[api.fixtures] cleanup DELETE /Contacts/${id} returned ${response.status}`,
+          );
+        }
+      } catch (error) {
+        console.warn(`[api.fixtures] cleanup DELETE /Contacts/${id} threw`, error);
+      }
+    }
+  },
+});
+
+export { expect };

--- a/src/ApiTests/tests/fixtures/api.fixtures.spec.ts
+++ b/src/ApiTests/tests/fixtures/api.fixtures.spec.ts
@@ -1,0 +1,108 @@
+import { StatusCodes } from 'http-status-codes';
+import { BaseApiClient } from '../../src/clients/base-api-client.js';
+import { ContactsClient } from '../../src/clients/contacts-client.js';
+import { ContactFactory } from '../../src/data/contact.factory.js';
+import { expect, test } from '../../src/fixtures/api.fixtures.js';
+
+test.describe('api fixtures — smoke', () => {
+  test('contactFactory fixture is the ContactFactory class', ({ contactFactory }) => {
+    expect(contactFactory).toBe(ContactFactory);
+    const contact = contactFactory.validContact();
+    expect(contact.firstName.length).toBeGreaterThan(0);
+    expect(contact.lastName.length).toBeGreaterThan(0);
+  });
+
+  test('contactsClient is a ContactsClient instance', ({ contactsClient }) => {
+    expect(contactsClient).toBeInstanceOf(ContactsClient);
+  });
+
+  test('successful create() registers the id in createdContacts', async ({
+    contactsClient,
+    contactFactory,
+    createdContacts,
+  }) => {
+    const before = createdContacts.ids.length;
+
+    const created = await contactsClient.create(contactFactory.validContact());
+    expect(created.status).toBe(StatusCodes.CREATED);
+    expect(created.id).toBeGreaterThan(0);
+
+    expect(createdContacts.ids).toHaveLength(before + 1);
+    expect(createdContacts.ids).toContain(created.id!);
+  });
+});
+
+test.describe.serial('contactsClient is per-test (not a singleton)', () => {
+  const seen: ContactsClient[] = [];
+
+  test('captures the client instance from the first test', ({ contactsClient }) => {
+    seen.push(contactsClient);
+    expect(seen).toHaveLength(1);
+  });
+
+  test('gets a distinct instance in the second test', ({ contactsClient }) => {
+    expect(seen).toHaveLength(1);
+    expect(contactsClient).not.toBe(seen[0]);
+  });
+});
+
+test.describe.serial('auto-cleanup after test teardown', () => {
+  const previouslyCreatedIds: number[] = [];
+
+  test('creates a contact through the fixture', async ({ contactsClient, contactFactory }) => {
+    const created = await contactsClient.create(contactFactory.validContact());
+    expect(created.status).toBe(StatusCodes.CREATED);
+    expect(created.id).toBeGreaterThan(0);
+    previouslyCreatedIds.push(created.id!);
+
+    const fetched = await contactsClient.getById(created.id!);
+    expect(fetched.status).toBe(StatusCodes.OK);
+  });
+
+  test('previously created contact is 404 after teardown', async ({ request }) => {
+    expect(previouslyCreatedIds).not.toHaveLength(0);
+    const rawClient = new ContactsClient(new BaseApiClient(request));
+    for (const id of previouslyCreatedIds) {
+      const response = await rawClient.getById(id);
+      expect(response.status).toBe(StatusCodes.NOT_FOUND);
+    }
+  });
+});
+
+test('teardown tolerates a contact already deleted inside the test', async ({
+  contactsClient,
+  contactFactory,
+}) => {
+  const created = await contactsClient.create(contactFactory.validContact());
+  expect(created.status).toBe(StatusCodes.CREATED);
+
+  const deleted = await contactsClient.delete(created.id!);
+  expect(deleted.status).toBe(StatusCodes.NO_CONTENT);
+  // If teardown throws on the already-deleted id, this test is marked failed post-hoc.
+});
+
+test.describe.serial('teardown continues after a failed delete', () => {
+  const realIds: number[] = [];
+
+  test('registers an unreachable id then creates a real contact', async ({
+    contactsClient,
+    contactFactory,
+    createdContacts,
+  }) => {
+    // Larger than int32.MaxValue: fails the {id:int} route constraint → 404, teardown must go on.
+    createdContacts.register(Number.MAX_SAFE_INTEGER);
+
+    const created = await contactsClient.create(contactFactory.validContact());
+    expect(created.status).toBe(StatusCodes.CREATED);
+    realIds.push(created.id!);
+  });
+
+  test('real contact from previous test is still cleaned up', async ({ request }) => {
+    expect(realIds).not.toHaveLength(0);
+    const rawClient = new ContactsClient(new BaseApiClient(request));
+    for (const id of realIds) {
+      const response = await rawClient.getById(id);
+      expect(response.status).toBe(StatusCodes.NOT_FOUND);
+    }
+  });
+});


### PR DESCRIPTION
Closes #60.

## What this change does

Adds task **T8** of [`docs/tasks/api-tests-framework-plan.md`](../blob/60-apitests-fixtures/docs/tasks/api-tests-framework-plan.md): Playwright fixtures that later specs (T10–T16) will consume so tests never have to think about client construction, factory access, or contact cleanup.

- `src/ApiTests/src/fixtures/api.fixtures.ts` — `test.extend<ApiFixtures>({...})` module with three test-scoped fixtures (`contactFactory`, `createdContacts`, `contactsClient`) and a re-export of `expect`. `contactsClient` is a private `TrackedContactsClient` subclass whose `create()` auto-registers the new id; teardown deletes tracked ids best-effort (swallows `204`/`404`, `console.warn` on anything else).
- `src/ApiTests/tests/fixtures/api.fixtures.spec.ts` — 10 tests: smoke (factory identity, client type, auto-registration), per-test client identity, `describe.serial` proving the created contact is `404` from a raw client after teardown, teardown-tolerates-already-deleted, and teardown-continues-after-a-failed-delete.

Full acceptance table and file list are on the issue: askrinnik/AddressBook2025#60.

## Non-obvious decisions

- **Empty destructuring pattern for zero-dep fixtures.** Playwright inspects fixture source to detect dependencies and throws `First argument must use the object destructuring pattern` if the first parameter isn't a destructuring pattern. So `contactFactory` and `createdContacts` use `async ({}, use) => ...`. ESLint's `no-empty-pattern` is suppressed on those two lines with a short comment.
- **Subclass over `Proxy` for tracking.** `TrackedContactsClient extends ContactsClient` and overrides `create()`. Keeps public types unchanged for callers and lets teardown reach `ContactsClient.prototype.delete` through a fresh, non-wrapped instance so tearing down never re-triggers tracking.
- **Best-effort teardown, no failure.** Each `DELETE` is wrapped in `try/catch`; `204` and `404` are silent. Anything else is `console.warn` — surfaces unexpected server behaviour without masking the actual test result. `Number.MAX_SAFE_INTEGER` is used as a synthetic "unreachable" id in the resilience spec: it exceeds int32 and fails the `{id:int}` route constraint, so DELETE returns 404 and the loop moves on.
- **Existing specs not migrated.** `problem-details.spec.ts` (T6) and `contact.factory.spec.ts` (T7) still construct clients directly. Migration is deferred to T10+ when real endpoint specs land, to keep this PR focused.

## Verification

- `npm run lint` in `src/ApiTests` — clean.
- `npx tsc --noEmit` in `src/ApiTests` — clean.
- `npx playwright test tests/fixtures/api.fixtures.spec.ts` against the local API — 10/10 passed with 7 workers.
- `dotnet build src/AddressBook.sln` — succeeded with no new warnings (no C# code was touched).
