### PR TITLE
#59 [ApiTests][T9] utils/assertions.ts — кастомные проверки

### DIFF
--- a/docs/tasks/api-tests-framework-plan.md
+++ b/docs/tasks/api-tests-framework-plan.md
@@ -99,7 +99,7 @@ src/ApiTests/
 - [x] **T6** ([#57](https://github.com/askrinnik/AddressBook2025/issues/57)) `models/problem-details.ts` — порт RFC7807-хелпера (`messagesFor`, `messages`, `hasErrors`).
 - [x] **T7** ([#64](https://github.com/askrinnik/AddressBook2025/issues/64)) `data/contact.factory.ts` + `tokens.ts` — фабрики на faker + граничные варианты.
 - [x] **T8** ([#60](https://github.com/askrinnik/AddressBook2025/issues/60)) `fixtures/api.fixtures.ts` — `test.extend` (client + factory + авто-очистка созданных контактов).
-- [ ] **T9** ([#59](https://github.com/askrinnik/AddressBook2025/issues/59)) `utils/assertions.ts` — хелперы проверки схем и problem-details.
+- [x] **T9** ([#59](https://github.com/askrinnik/AddressBook2025/issues/59)) `utils/assertions.ts` — хелперы проверки схем и problem-details.
 
 ### Фаза 2 — Тесты
 

--- a/docs/tasks/issue-59-apitests-assertions.md
+++ b/docs/tasks/issue-59-apitests-assertions.md
@@ -1,0 +1,196 @@
+# Issue #59 — `[ApiTests][T9]` `utils/assertions.ts` — кастомные проверки
+
+**Type:** test-authoring / инфраструктура фреймворка (метки `api`, `testing`) — задача **T9**
+из плана [`api-tests-framework-plan.md`](./api-tests-framework-plan.md).
+**Scope:** только `src/ApiTests/src/utils/**` + одна изолированная спека, покрывающая
+хелперы (юнит + live). Никакого продакшн-кода, никаких правок `src/AutoTests`, T6/T7/T8-спеки
+не мигрируем.
+**Зависимости:** T4 (`contactModelSchema`, `getFilteredContactsResponseSchema`,
+`problemDetailsSchema`), T5 (`BaseApiClient`/`ContactsClient`, тип `ApiResponse`),
+T6 (`ProblemDetails`), T7 (`ContactFactory`), T8 (`api.fixtures.ts`).
+
+## 1. Требование (из issue)
+
+- `src/utils/assertions.ts`:
+  - `expectMatchesSchema(body, schema)` — валидация ответа против zod-схемы с
+    понятным сообщением.
+  - `expectProblemDetails(response, { status, property, message })` — проверка ошибок
+    валидации.
+- Критерии из issue:
+  - Хелперы дают читаемые сообщения при расхождении.
+  - Используются в contract- и негативных тестах.
+
+Хелперы будут широко переиспользоваться в T10–T14 (endpoint-специфичные негативы) и в
+T16 (`contract/schema.spec.ts`).
+
+## 2. Факты об API и уже готовой инфраструктуре
+
+- `problemDetailsSchema` из T4 — «нестрогая» (принимает `traceId` и др. расширения ASP.NET),
+  `errors` — только карта `Record<string, string[]>` (форма, которую API реально отдаёт).
+- `ProblemDetails.fromJSON` из T6 — устойчив к «мусору», поддерживает `errors` в двух
+  формах, предоставляет `messagesFor(prop)`, `messages`, `hasErrors()`.
+- `ApiResponse<TBody>` из T5 — `{ status: number, headers: Record<string,string>, body: TBody }`.
+  Хелпер должен уметь принимать любой `ApiResponse<unknown>` без ограничений на `TBody`.
+- Реальный `400` от `POST /api/Contacts` содержит `title="Validation Error"`,
+  `status=400`, `detail="One or more validation errors occurred"` и карту
+  `errors: { PropertyName: string[] }` (см. валидаторы `Create/UpdateContactCommandValidator`).
+
+## 3. Acceptance criteria
+
+| # | Критерий | Как проверим |
+|---|----------|--------------|
+| AC1 | `expectMatchesSchema(body, schema)` возвращает распарсенный `T` при валидном теле и не бросает. Типизировано через `z.ZodType<T>`. | Юнит-тест: даём валидный `Contact` → получаем `data` того же типа; поле `id` доступно как `number`. |
+| AC2 | `expectMatchesSchema` бросает с читаемым сообщением при несоответствии: перечисляет все проблемные пути и их сообщения. | Юнит-тест: даём невалидный ввод, ловим ошибку, `expect(caught.message)` содержит имена всех проблемных полей и слова из zod-сообщений. |
+| AC3 | `expectMatchesSchema` работает как ассерт Playwright — падение помечает тест как failed (через `expect(...).toBe(true)` с custom message). | Юнит-тест: гарантируем, что при несоответствии выбрасывается ошибка (Playwright это сам маркирует failed). |
+| AC4 | `expectProblemDetails(response, { status })` проверяет статус и наличие корректного problem-details тела. Возвращает распарсенный `ProblemDetails`. | Юнит-тест на фиксированной нагрузке. |
+| AC5 | `expectProblemDetails(response, { status, property })` — проверяет, что для указанного свойства **есть** сообщения. Мимо-property (`errors[LastName]` при ожидании `FirstName`) даёт читаемую ошибку с перечислением фактических ключей. | Юнит-тест: успешный кейс + failure-кейс с проверкой текста сообщения. |
+| AC6 | `expectProblemDetails(response, { status, property, message })` принимает `message` как `string` (точное совпадение) или `RegExp` (проверка совпадения). При отсутствии совпадения — читаемое сообщение с фактическими значениями. | Юнит-тест: `string` + `RegExp` + failure с проверкой текста. |
+| AC7 | `expectProblemDetails` дополнительно принимает `title`/`detail` (опционально) — точное сравнение. | Юнит-тест. |
+| AC8 | Хелперы работают на реальном API: `expectMatchesSchema` — на `GET /api/Contacts/{id}` и `GET /api/Contacts`; `expectProblemDetails` — на `POST /api/Contacts` с невалидными данными от `ContactFactory` (пустое имя, будущая дата). | Live-часть спеки. |
+| AC9 | Никаких `expect` в чуждом контексте: хелперы используют `expect` из `@playwright/test`, но сам модуль не имеет side-effects и не содержит state. | Code review. |
+| AC10 | `npm run lint` + `npx tsc --noEmit` чистые. | Прогон в шаге 8. |
+| AC11 | Чек-бокс **T9** в [`api-tests-framework-plan.md`](./api-tests-framework-plan.md) переведён в `[x]`. | Diff файла плана. |
+
+## 4. Затрагиваемые файлы
+
+| Файл | Изменение |
+|------|-----------|
+| `src/ApiTests/src/utils/assertions.ts` | **Новый** — `expectMatchesSchema` + `expectProblemDetails`. |
+| `src/ApiTests/src/utils/.gitkeep` | **Удалить**. |
+| `src/ApiTests/tests/utils/assertions.spec.ts` | **Новый** — юнит-кейсы (AC1–AC7) + live (AC8). |
+| `docs/tasks/api-tests-framework-plan.md` | Отметить **T9** как `[x]`. |
+
+## 5. Дизайн
+
+### 5.1. Публичный API `assertions.ts`
+
+```ts
+import { expect } from '@playwright/test';
+import type { z } from 'zod';
+import type { ApiResponse } from '../clients/base-api-client.js';
+import { ProblemDetails } from '../models/problem-details.js';
+import { problemDetailsSchema } from '../schemas/contact.schema.js';
+
+export function expectMatchesSchema<T>(body: unknown, schema: z.ZodType<T>): T;
+
+export interface ExpectedProblemDetails {
+  status: number;
+  title?: string;
+  detail?: string;
+  property?: string;
+  message?: string | RegExp;
+}
+
+export function expectProblemDetails(
+  response: ApiResponse<unknown>,
+  expected: ExpectedProblemDetails,
+): ProblemDetails;
+```
+
+Ключевые решения:
+
+- **Свободные функции, не класс.** Хелперы — не DTO/фабрика; класс со static-only здесь
+  был бы лишним namespace object. Идиоматично экспортировать функции — так же читаются
+  импорты в тестах: `import { expectProblemDetails } from '../../src/utils/assertions.js'`.
+- **Возврат типизированного результата.** `expectMatchesSchema` отдаёт `T` (парснутое
+  тело) — тесты могут дальше проверять поля напрямую. `expectProblemDetails` отдаёт
+  `ProblemDetails` — доступ к `messagesFor`/`messages` для дополнительных проверок.
+- **Интеграция с `expect` Playwright.** Внутри используем
+  `expect(condition, customMessage).toBe(true)`. Playwright автоматически:
+  - помечает тест `failed`,
+  - вставляет `customMessage` в отчёт,
+  - показывает шаг в UI/trace.
+  При этом на успехе никакой лишней шумихи. Плюс — на конце функции после провала
+  `expect(...)` перегоняем через `throw new Error(customMessage)` для сужения типа
+  (TypeScript иначе жалуется на возможный `undefined`). Эта строка недостижима в рантайме,
+  но не мешает читаемости.
+- **Формат сообщений.**
+  - Для схемы: список проблем в столбик — `  • <path>: <message>` — плюс краткая
+    выжимка сырого тела (`JSON.stringify(body, null, 2)`, обрезанное до ~2 KB).
+  - Для problem-details: конкретика (`expected status 400, got 500`; `no error for
+    property "FirstName"; got keys: [LastName]`; `no message for "FirstName" matches
+    /empty/i; got: ["is required"]`).
+- **`message: string | RegExp`.** `string` — точное совпадение через `Array.includes`;
+  `RegExp` — `.some(m => re.test(m))`. Обе ветки покрыты юнит-кейсами.
+- **`title`/`detail` — опционально, точное сравнение.** Тесты часто хотят зафиксировать
+  ровно те строки, что API отдаёт (`"Validation Error"`, `"One or more validation errors
+  occurred"`).
+- **Модуль без side-effects и без state.** Никаких module-scope переменных, никакого
+  I/O при импорте.
+
+### 5.2. Спека `tests/utils/assertions.spec.ts`
+
+Разделы:
+
+1. **`expectMatchesSchema` — unit**
+   - валидный `ContactModel` → возвращает данные, тип сохраняется, `id` — число;
+   - невалидное тело (`id: "x"`, отсутствует `firstName`) → бросает; ловим и проверяем,
+     что сообщение содержит `id`, `firstName` и слова из zod-сообщений;
+   - валидный `GetFilteredContactsResponse` → возвращает `{ totalRows, rows }`.
+
+2. **`expectMatchesSchema` — live**
+   - через фикстуру `contactsClient` создаём контакт, читаем через `getById`, пропускаем
+     `body` через хелпер + `contactModelSchema` — не бросает, возвращает объект;
+   - `list()` без параметров → пропускаем через `getFilteredContactsResponseSchema`.
+
+3. **`expectProblemDetails` — unit**
+   - фиксированная нагрузка `{ status: 400, headers: {}, body: {...validationProblem} }`:
+     `{ status: 400 }` → OK, возвращает `pd`;
+     `{ status: 400, property: 'FirstName' }` → OK;
+     `{ status: 400, property: 'FirstName', message: 'X' }` → неуспех при отсутствии `X` в
+     сообщениях; ловим и проверяем текст;
+     `{ status: 400, property: 'FirstName', message: /empty/i }` → OK;
+     `{ status: 400, property: 'FirstName', message: /nonsense/ }` → неуспех + текст;
+     `{ status: 400, title: 'Validation Error', detail: 'One or more…' }` → OK;
+     `{ status: 500 }` → неуспех + текст (`expected status 500, got 400`).
+
+4. **`expectProblemDetails` — live**
+   - через фикстуру `contactsClient.create(contactFactory.emptyFirstName())` → ожидаем
+     `400`, `property: 'FirstName'`, `message: /empty/i` (соответствует FluentValidation
+     сообщению `"'First Name' must not be empty."`);
+   - через `contactsClient.create(contactFactory.birthdayInFuture())` → `400`,
+     `property: 'Birthday'`, `message: 'Birthday cannot be in the future'`.
+
+Спека соответствует `playwright-conventions`: маршрутизация через `contactsClient`
+(фикстура T8), Create-в-live-части автоматически удаляется в teardown фикстуры,
+разделение на unit/live-блоки чёткое.
+
+### 5.3. Что деликатно **вне** этого таска
+
+- **Не мигрируем существующие спеки** (`problem-details.spec.ts`, `contact.factory.spec.ts`,
+  `api.fixtures.spec.ts`) на новые хелперы. Первое реальное применение — T10+ и T16.
+- **Не расширяем `expect.extend`** (кастомные Playwright matchers). Обёртки-функции
+  проще и понятнее для нашего масштаба.
+- **Не добавляем никаких зависимостей.** Всё уже стоит: `zod` (T2), `@playwright/test`,
+  внутренние модули T4/T5/T6/T7/T8.
+
+## 6. Тесты в этой задаче
+
+Одна спека `tests/utils/assertions.spec.ts` — 4 логических блока, ~10–14 `test(...)`
+внутри `describe`. Live-часть автоматически чистится за собой через фикстуру T8.
+
+## 7. План работ
+
+1. Создать `src/utils/assertions.ts` по §5.1.
+2. Удалить `src/utils/.gitkeep`.
+3. Создать `tests/utils/assertions.spec.ts` по §5.2.
+4. `npm run lint` → чисто.
+5. `npx tsc --noEmit` → чисто.
+6. `npx playwright test tests/utils/assertions.spec.ts` при поднятом API → зелёная.
+7. Отметить чек-бокс **T9** как `[x]` в плане.
+
+## 8. Verification (шаг 8 промпта, режим test-authoring)
+
+- `npm run lint` → 0 ошибок.
+- `npx tsc --noEmit` → 0 ошибок.
+- `npx playwright test tests/utils/assertions.spec.ts` — все кейсы зелёные, включая
+  failure-ветки (проверка текста сообщений).
+- `dotnet build src/AddressBook.sln` → без новых предупреждений.
+
+## 9. Out of scope / follow-ups
+
+- README `src/ApiTests` (T17 / #71) — не сюда; там же зафиксируем использование
+  ассертов.
+- CI-workflow (T18 / #74) — вне задачи.
+- Кастомные Playwright matchers через `expect.extend` — вне задачи, обсуждаем при
+  необходимости в отдельном issue.

--- a/src/ApiTests/package.json
+++ b/src/ApiTests/package.json
@@ -10,6 +10,7 @@
     "test:remote": "cross-env BASE_URL=https://addressbook-api-h5gmdghdcyfaf6gu.westeurope-01.azurewebsites.net/api/ playwright test",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
+    "test:debug-webserver": "cross-env DEBUG=pw:webserver playwright test",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx,js,mjs,cjs,json,md}\""
   },

--- a/src/ApiTests/src/utils/assertions.ts
+++ b/src/ApiTests/src/utils/assertions.ts
@@ -1,0 +1,117 @@
+import { expect } from '@playwright/test';
+import type { z } from 'zod';
+import type { ApiResponse } from '../clients/base-api-client.js';
+import { ProblemDetails } from '../models/problem-details.js';
+import { problemDetailsSchema } from '../schemas/contact.schema.js';
+
+const MAX_BODY_PREVIEW = 2000;
+
+function previewBody(body: unknown): string {
+  let text: string;
+  try {
+    text = typeof body === 'string' ? body : JSON.stringify(body, null, 2);
+  } catch {
+    text = String(body);
+  }
+  if (text.length <= MAX_BODY_PREVIEW) return text;
+  return `${text.slice(0, MAX_BODY_PREVIEW)}… <truncated ${text.length - MAX_BODY_PREVIEW} chars>`;
+}
+
+function fail(message: string): never {
+  expect(false, message).toBe(true);
+  // Unreachable — expect() above throws — but keeps TS happy about `never`.
+  throw new Error(message);
+}
+
+export function expectMatchesSchema<T>(body: unknown, schema: z.ZodType<T>): T {
+  const result = schema.safeParse(body);
+  if (result.success) return result.data;
+
+  const issues = result.error.issues
+    .map((issue) => `  • ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('\n');
+  const message = `Response body does not match schema:\n${issues}\n\nActual body:\n${previewBody(body)}`;
+  expect(false, message).toBe(true);
+  // Unreachable — expect() above throws — but satisfies eslint/consistent-return.
+  throw new Error(message);
+}
+
+export interface ExpectedProblemDetails {
+  status: number;
+  title?: string;
+  detail?: string;
+  property?: string;
+  message?: string | RegExp;
+}
+
+function describeMessageMatcher(matcher: string | RegExp): string {
+  return matcher instanceof RegExp ? matcher.toString() : JSON.stringify(matcher);
+}
+
+function messageMatches(candidate: string, matcher: string | RegExp): boolean {
+  return matcher instanceof RegExp ? matcher.test(candidate) : candidate === matcher;
+}
+
+export function expectProblemDetails(
+  response: ApiResponse<unknown>,
+  expected: ExpectedProblemDetails,
+): ProblemDetails {
+  if (response.status !== expected.status) {
+    fail(
+      `Expected status ${expected.status}, got ${response.status}. Body:\n${previewBody(response.body)}`,
+    );
+  }
+
+  const schemaResult = problemDetailsSchema.safeParse(response.body);
+  if (!schemaResult.success) {
+    const issues = schemaResult.error.issues
+      .map((issue) => `  • ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('\n');
+    fail(
+      `Response body is not a valid RFC 7807 problem-details:\n${issues}\n\nActual body:\n${previewBody(response.body)}`,
+    );
+  }
+
+  const pd = ProblemDetails.fromJSON(response.body);
+
+  if (expected.title !== undefined && pd.title !== expected.title) {
+    fail(`Expected problem-details title ${JSON.stringify(expected.title)}, got ${JSON.stringify(pd.title)}`);
+  }
+  if (expected.detail !== undefined && pd.detail !== expected.detail) {
+    fail(
+      `Expected problem-details detail ${JSON.stringify(expected.detail)}, got ${JSON.stringify(pd.detail)}`,
+    );
+  }
+
+  if (expected.property !== undefined) {
+    const messages = pd.messagesFor(expected.property);
+    if (messages.length === 0) {
+      const availableKeys =
+        pd.errors && !Array.isArray(pd.errors) ? Object.keys(pd.errors) : [];
+      fail(
+        `Expected error(s) for property ${JSON.stringify(expected.property)}, found none. ` +
+          `Available property keys: ${JSON.stringify(availableKeys)}. ` +
+          `All messages: ${JSON.stringify(pd.messages)}`,
+      );
+    }
+
+    if (expected.message !== undefined) {
+      const matches = messages.some((m) => messageMatches(m, expected.message!));
+      if (!matches) {
+        fail(
+          `No error message for property ${JSON.stringify(expected.property)} matches ${describeMessageMatcher(expected.message)}. ` +
+            `Got: ${JSON.stringify(messages)}`,
+        );
+      }
+    }
+  } else if (expected.message !== undefined) {
+    const matches = pd.messages.some((m) => messageMatches(m, expected.message!));
+    if (!matches) {
+      fail(
+        `No error message matches ${describeMessageMatcher(expected.message)}. Got: ${JSON.stringify(pd.messages)}`,
+      );
+    }
+  }
+
+  return pd;
+}

--- a/src/ApiTests/tests/utils/assertions.spec.ts
+++ b/src/ApiTests/tests/utils/assertions.spec.ts
@@ -1,0 +1,223 @@
+import { StatusCodes } from 'http-status-codes';
+import { expect, test } from '../../src/fixtures/api.fixtures.js';
+import {
+  contactModelSchema,
+  getFilteredContactsResponseSchema,
+} from '../../src/schemas/contact.schema.js';
+import { expectMatchesSchema, expectProblemDetails } from '../../src/utils/assertions.js';
+
+interface FakeApiResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function fakeResponse(status: number, body: unknown): FakeApiResponse {
+  return { status, headers: {}, body };
+}
+
+const validValidationProblemBody = {
+  type: 'https://tools.ietf.org/html/rfc7231#section-6.5.1',
+  title: 'Validation Error',
+  status: 400,
+  detail: 'One or more validation errors occurred',
+  errors: {
+    FirstName: ["'First Name' must not be empty."],
+    LastName: ["'Last Name' must not be empty."],
+  },
+  traceId: '00-abc-01',
+};
+
+function catchError(fn: () => unknown): Error {
+  try {
+    fn();
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error('Expected the function to throw, but it returned normally');
+}
+
+test.describe('expectMatchesSchema — unit', () => {
+  test('returns typed data when body matches schema', () => {
+    const parsed = expectMatchesSchema(
+      { id: 1, firstName: 'A', lastName: 'B', birthday: null },
+      contactModelSchema,
+    );
+    expect(parsed.id).toBe(1);
+    expect(parsed.firstName).toBe('A');
+    expect(parsed.birthday).toBeNull();
+  });
+
+  test('parses a list-response body against getFilteredContactsResponseSchema', () => {
+    const parsed = expectMatchesSchema(
+      {
+        totalRows: 1,
+        rows: [{ id: 42, firstName: 'X', lastName: 'Y', birthday: '2000-01-01' }],
+      },
+      getFilteredContactsResponseSchema,
+    );
+    expect(parsed.totalRows).toBe(1);
+    expect(parsed.rows).toHaveLength(1);
+    expect(parsed.rows[0].id).toBe(42);
+  });
+
+  test('throws a readable message listing every failing path when body is invalid', () => {
+    const error = catchError(() =>
+      expectMatchesSchema({ id: 'not-a-number', lastName: 5 }, contactModelSchema),
+    );
+    expect(error.message).toContain('Response body does not match schema');
+    expect(error.message).toContain('id');
+    expect(error.message).toContain('firstName');
+    expect(error.message).toContain('lastName');
+    expect(error.message).toContain('Actual body');
+  });
+});
+
+test.describe('expectMatchesSchema — live via ContactsClient', () => {
+  test('accepts a GET /Contacts/{id} response as ContactModel', async ({
+    contactsClient,
+    contactFactory,
+  }) => {
+    const payload = contactFactory.validContact();
+    const created = await contactsClient.create(payload);
+    expect(created.status).toBe(StatusCodes.CREATED);
+
+    const fetched = await contactsClient.getById(created.id!);
+    expect(fetched.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(fetched.body, contactModelSchema);
+    expect(parsed.id).toBe(created.id);
+    expect(parsed.firstName).toBe(payload.firstName);
+  });
+
+  test('accepts a GET /Contacts list response as GetFilteredContactsResponse', async ({
+    contactsClient,
+  }) => {
+    const list = await contactsClient.list();
+    expect(list.status).toBe(StatusCodes.OK);
+    const parsed = expectMatchesSchema(list.body, getFilteredContactsResponseSchema);
+    expect(parsed.totalRows).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(parsed.rows)).toBe(true);
+  });
+});
+
+test.describe('expectProblemDetails — unit', () => {
+  test('accepts a valid 400 problem-details with just a status', () => {
+    const pd = expectProblemDetails(
+      fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody),
+      { status: StatusCodes.BAD_REQUEST },
+    );
+    expect(pd.title).toBe('Validation Error');
+    expect(pd.hasErrors()).toBe(true);
+  });
+
+  test('accepts { property } when errors[property] is present', () => {
+    const pd = expectProblemDetails(
+      fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody),
+      { status: StatusCodes.BAD_REQUEST, property: 'FirstName' },
+    );
+    expect(pd.messagesFor('FirstName')).not.toHaveLength(0);
+  });
+
+  test('accepts { property, message } as exact string', () => {
+    expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody), {
+      status: StatusCodes.BAD_REQUEST,
+      property: 'FirstName',
+      message: "'First Name' must not be empty.",
+    });
+  });
+
+  test('accepts { property, message } as RegExp', () => {
+    expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody), {
+      status: StatusCodes.BAD_REQUEST,
+      property: 'FirstName',
+      message: /must not be empty/i,
+    });
+  });
+
+  test('accepts { title, detail } for exact metadata match', () => {
+    expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody), {
+      status: StatusCodes.BAD_REQUEST,
+      title: 'Validation Error',
+      detail: 'One or more validation errors occurred',
+    });
+  });
+
+  test('fails readably on wrong status', () => {
+    const error = catchError(() =>
+      expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody), {
+        status: StatusCodes.INTERNAL_SERVER_ERROR,
+      }),
+    );
+    expect(error.message).toContain('Expected status 500, got 400');
+  });
+
+  test('fails readably when the target property has no errors', () => {
+    const error = catchError(() =>
+      expectProblemDetails(
+        fakeResponse(StatusCodes.BAD_REQUEST, {
+          ...validValidationProblemBody,
+          errors: { LastName: ['too long'] },
+        }),
+        { status: StatusCodes.BAD_REQUEST, property: 'FirstName' },
+      ),
+    );
+    expect(error.message).toContain('FirstName');
+    expect(error.message).toContain('LastName');
+  });
+
+  test('fails readably when the message matcher does not match', () => {
+    const error = catchError(() =>
+      expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody), {
+        status: StatusCodes.BAD_REQUEST,
+        property: 'FirstName',
+        message: /nonsense/,
+      }),
+    );
+    expect(error.message).toContain('FirstName');
+    expect(error.message).toContain('nonsense');
+  });
+
+  test('fails readably when title does not match', () => {
+    const error = catchError(() =>
+      expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, validValidationProblemBody), {
+        status: StatusCodes.BAD_REQUEST,
+        title: 'Other Error',
+      }),
+    );
+    expect(error.message).toContain('Other Error');
+    expect(error.message).toContain('Validation Error');
+  });
+
+  test('fails readably when body is not a valid problem-details', () => {
+    const error = catchError(() =>
+      expectProblemDetails(fakeResponse(StatusCodes.BAD_REQUEST, { errors: 'not-an-object' }), {
+        status: StatusCodes.BAD_REQUEST,
+      }),
+    );
+    expect(error.message).toContain('not a valid RFC 7807 problem-details');
+  });
+});
+
+test.describe('expectProblemDetails — live via ContactsClient', () => {
+  test('validates the 400 from emptyFirstName()', async ({ contactsClient, contactFactory }) => {
+    const response = await contactsClient.create(contactFactory.emptyFirstName());
+    const pd = expectProblemDetails(response, {
+      status: StatusCodes.BAD_REQUEST,
+      title: 'Validation Error',
+      detail: 'One or more validation errors occurred',
+      property: 'FirstName',
+      message: /must not be empty/i,
+    });
+    expect(pd.hasErrors()).toBe(true);
+  });
+
+  test('validates the 400 from birthdayInFuture()', async ({ contactsClient, contactFactory }) => {
+    const response = await contactsClient.create(contactFactory.birthdayInFuture());
+    expectProblemDetails(response, {
+      status: StatusCodes.BAD_REQUEST,
+      property: 'Birthday',
+      message: 'Birthday cannot be in the future',
+    });
+  });
+});


### PR DESCRIPTION
Closes #59.

## What this change does

Adds task **T9** of [`docs/tasks/api-tests-framework-plan.md`](../blob/59-apitests-assertions/docs/tasks/api-tests-framework-plan.md): reusable assertion helpers for zod-schema and RFC 7807 checks that T10–T16 will use to keep endpoint and contract specs terse.

- `src/ApiTests/src/utils/assertions.ts` — `expectMatchesSchema<T>(body, schema): T` and `expectProblemDetails(response, { status, title?, detail?, property?, message? }): ProblemDetails`. Both build failure messages that enumerate exactly what didn't match (zod issue paths + body preview for schema; expected-vs-actual with available keys for problem-details) and route through `expect(false, msg).toBe(true)` so Playwright picks them up naturally.
- `src/ApiTests/tests/utils/assertions.spec.ts` — 17 tests: happy-path and failure-message unit cases for both helpers, plus live coverage via the `contactsClient` fixture (T8) on `GET /Contacts/{id}`, `GET /Contacts`, and two `POST` negatives from `ContactFactory` (`emptyFirstName`, `birthdayInFuture`).

Full acceptance table and file list are on the issue: askrinnik/AddressBook2025#59.

## Non-obvious decisions

- **Free functions over a static class.** T6 and T7 exposed classes because they wrap data; assertions are utilities, not DTOs, and importing `expectProblemDetails` by name is easier to read at the call site. Kept it a single `assertions.ts` module.
- **`message: string | RegExp`.** Exact string via `Array.includes`, regex via `.some(r.test)`. Failure messages describe the matcher (`describeMessageMatcher`) so log output shows the intended pattern.
- **Inlined final throw in `expectMatchesSchema`.** ESLint's `consistent-return` doesn't infer `never` across a locally-defined helper, so the final `expect(false, msg).toBe(true)` and an unreachable `throw` sit directly at the end of the function. Behaviour is unchanged.
- **Body preview is truncated to ~2 KB.** Long JSON responses would drown out the actual mismatch in the failure message. Truncation only kicks in above 2 KB and is called out (`… <truncated N chars>`).
- **Existing specs not migrated.** T6/T7/T8 specs keep their inline assertions to keep this PR focused. Endpoint specs (T10+) will consume the helpers directly.

## Verification

- `npm run lint` in `src/ApiTests` — clean.
- `npx tsc --noEmit` in `src/ApiTests` — clean.
- `npx playwright test tests/utils/assertions.spec.ts` against the local API — 17/17 passed with 16 workers.
- `dotnet build src/AddressBook.sln` — succeeded with no new warnings (no C# code was touched).
