### PR TITLE
#65 [ApiTests][T10] tests/contacts/get-list.spec.ts

### DIFF
--- a/docs/tasks/api-tests-framework-plan.md
+++ b/docs/tasks/api-tests-framework-plan.md
@@ -103,7 +103,7 @@ src/ApiTests/
 
 ### Фаза 2 — Тесты
 
-- [ ] **T10** ([#65](https://github.com/askrinnik/AddressBook2025/issues/65)) `tests/contacts/get-list.spec.ts` — поиск, пустой результат, кодирование query, независимость от seed.
+- [x] **T10** ([#65](https://github.com/askrinnik/AddressBook2025/issues/65)) `tests/contacts/get-list.spec.ts` — поиск, пустой результат, кодирование query, независимость от seed.
 - [ ] **T11** ([#67](https://github.com/askrinnik/AddressBook2025/issues/67)) `tests/contacts/get-by-id.spec.ts` — созданный контакт, `404`, нечисловой id → `404`.
 - [ ] **T12** ([#69](https://github.com/askrinnik/AddressBook2025/issues/69)) `tests/contacts/create.spec.ts` — валидный с/без birthday, границы 30/31, пусто, баг триммінга `"   "`, будущая дата → `400` + problem-details, «сегодня» → OK.
 - [ ] **T13** ([#73](https://github.com/askrinnik/AddressBook2025/issues/73)) `tests/contacts/update.spec.ts` — **PUT (новое покрытие)**: полное/частичное обновление, `404`, валидация `400`, границы.

--- a/docs/tasks/issue-65-apitests-get-list.md
+++ b/docs/tasks/issue-65-apitests-get-list.md
@@ -1,0 +1,136 @@
+# Issue #65 — `[ApiTests][T10]` `tests/contacts/get-list.spec.ts`
+
+**Type:** test-authoring (метки `api`, `testing`) — задача **T10** из плана
+[`api-tests-framework-plan.md`](./api-tests-framework-plan.md). **Первый** реальный
+endpoint-спек: с этой задачи начинается Фаза 2.
+**Scope:** только `src/ApiTests/tests/contacts/get-list.spec.ts`. Никакого продакшн-кода,
+никаких правок `src/AutoTests` и никаких существующих спек.
+**Зависимости:** T4 (`getFilteredContactsResponseSchema`), T5 (`ContactsClient`),
+T7 (`ContactFactory` + `newTestToken` / `RUN_TOKEN`), T8 (`api.fixtures.ts` — авто-очистка
+`contactsClient.create`), T9 (`expectMatchesSchema`).
+
+## 1. Требование (из issue)
+
+Тесты `GET /api/Contacts` (список + поиск):
+
+- Получить список — ответ `200`, структура `{ TotalRows, Rows }`, `Rows.length === TotalRows`.
+- Поиск по созданному уникальному токену возвращает ровно ожидаемые контакты (self-contained).
+- Пустой результат поиска по заведомо несуществующему токену.
+- Корректное кодирование query (терм со спецсимволами / пробелами).
+- Независимость от seed-данных.
+
+Критерии из issue:
+
+- Тесты создают/чистят свои данные через фикстуры.
+- Нет привязки к конкретным seed-контактам.
+
+## 2. Факты об API (проверено по коду `AddressBook.Api`)
+
+- **Контроллер** [`ContactsController.Get`](../../src/AddressBook.Api/Controllers/ContactsController.cs)
+  принимает `[FromQuery] string? search` и всегда возвращает `200 OK` с
+  `GetFilteredContactsResponse { TotalRows: int, Rows: ContactModel[] }`.
+- **Репозиторий**
+  [`AddressBookRepository.RetrieveManyAsync`](../../src/AddressBook.Api/DataAccess/AddressBookRepository.cs):
+  - `IsNullOrWhiteSpace(searchText)` → возвращает **все** контакты (в т.ч. seed + всё,
+    что накопили другие прогоны);
+  - иначе → фильтр `FirstName.Contains(searchText) || LastName.Contains(searchText)`.
+    EF Core → SQL Server `LIKE '%…%'`; по умолчанию **case-insensitive** (collation `_CI_`).
+- **Handler** [`GetFilteredContactsQueryHandler`](../../src/AddressBook.Api/Application/GetFilteredContactsQueryHandler.cs)
+  всегда выставляет `TotalRows = Rows.Length` — тавтологическое равенство, гарантия схемы.
+- **`RUN_TOKEN`** (T7) стабилен на процесс; embedded в happy-path именах фабрики.
+  `newTestToken()` уникален per invocation. Значит: поиск по свежесгенерированному
+  `newTestToken()` **точно** не найдёт ни один контакт, созданный до этого вызова —
+  безопасный «заведомо несуществующий» токен, при этом не зависящий от чужих прогонов.
+
+## 3. Acceptance criteria
+
+| # | Критерий | Как проверим |
+|---|----------|--------------|
+| AC1 | `GET /api/Contacts` (без `search`) → статус `200` и валидная схема `getFilteredContactsResponseSchema`. | Тест `returns 200 with valid schema` — `expectMatchesSchema`. |
+| AC2 | Инвариант `Rows.length === TotalRows` в ответе списка. | Тот же тест — `expect(parsed.rows.length).toBe(parsed.totalRows)`. |
+| AC3 | Список содержит созданные тестом контакты (self-contained: проверяем через `.some(r => r.id === created.id)`, а не через фиксированное число). | В том же тесте — создаём один контакт, ищем его в `Rows` по `id`. |
+| AC4 | Поиск по локально сгенерированному токену возвращает **ровно** ожидаемое число созданных контактов и **не** возвращает других. | Тест `search by unique local token returns exactly the created contacts` — создаём 2 контакта с этим токеном в `firstName`, поиск возвращает `totalRows === 2` и `rows[*].id ∋` оба id. |
+| AC5 | Поиск по гарантированно несуществующему токену возвращает `TotalRows === 0`, `Rows === []`. | Тест `unknown token returns empty result`. |
+| AC6 | Спец-символ URL (`&`) в query кодируется и доходит до API как есть. | Тест `search term with '&' is URL-encoded correctly` — создаём контакт с `firstName = "Q&A-<token>"`, поиск возвращает ровно его. |
+| AC7 | Пробел в query кодируется и доходит как есть (то есть API находит контакт по substring c пробелом). | Тест `search term with spaces is URL-encoded correctly`. |
+| AC8 | Ни один тест не привязан к seed-контактам (`id 1 John Doe`, `id 2 Jane Smith`) и не полагается на «был только один контакт до нас». | Code review + отсутствие любых `totalRows === <const>` без предварительного создания того же числа контактов; никакие тесты не читают `Rows[0]` без фильтрации по своему `id`. |
+| AC9 | Все создания идут через `contactsClient.create` (фикстура T8) — автоматическая teardown-очистка. Никаких ручных `delete` в тестах. | Code review + прогон: после спеки поиск по `RUN_TOKEN`/токенам должен вернуть 0 (по факту — teardown уже отработал). |
+| AC10 | `npm run lint` + `npx tsc --noEmit` чистые. | Прогон в шаге 8. |
+| AC11 | Чек-бокс **T10** в [`api-tests-framework-plan.md`](./api-tests-framework-plan.md) переведён в `[x]`. | Diff файла плана. |
+
+## 4. Затрагиваемые файлы
+
+| Файл | Изменение |
+|------|-----------|
+| `src/ApiTests/tests/contacts/get-list.spec.ts` | **Новый** — единственный спек T10. |
+| `src/ApiTests/tests/contacts/.gitkeep` | **Удалить**. |
+| `docs/tasks/api-tests-framework-plan.md` | Отметить **T10** как `[x]`. |
+
+## 5. Дизайн спеки
+
+Импорты — все через фикстуры и хелперы предыдущих задач: `test`/`expect` из
+`api.fixtures.js`, `getFilteredContactsResponseSchema`, `expectMatchesSchema`,
+`newTestToken`.
+
+```
+test.describe('GET /api/Contacts — list', () => {
+  1. returns 200 with valid schema; Rows.length === TotalRows; includes created id
+})
+
+test.describe('GET /api/Contacts?search — search', () => {
+  2. by unique local token returns exactly the two created contacts
+  3. by an unknown token returns TotalRows === 0
+  4. with '&' is URL-encoded correctly and finds the marker contact
+  5. with spaces is URL-encoded correctly and finds the marker contact
+})
+```
+
+Ключевые решения:
+
+- **`totalRows === rows.length` — единственный «структурный» инвариант.** Никаких
+  `totalRows === <N>` в общем случае, только там, где мы контролируем ровно `N`
+  созданных нами контактов и уверенно фильтруем по своему токену.
+- **`newTestToken()` как «заведомо несуществующий»** — свежий, не использованный ни в
+  одном create(). Не полагаемся на длинные «магические» строки.
+- **`marker`-контакты для encoding-тестов** имеют distinctive `firstName` (`"Q&A-<token>"`,
+  `"Hi There <token>"`); длина строго ≤ 30 (проверим в коде через `.slice(0, 30)` на
+  всякий случай).
+- **Никаких прямых `delete`** — всё, что мы создаём через `contactsClient.create`,
+  автоматически удалится в teardown фикстуры T8.
+- **Никакой зависимости от seed-данных.** Пример: тест «список» проверяет наличие
+  **своего** id, а не «list is non-empty and TotalRows > 0».
+
+### 5.1. Что делаем со спец-символами SQL LIKE
+
+`Contains` → `LIKE '%…%'`. Спец-символы SQL LIKE — `%`, `_`, `[`, `]`. Их поведение
+на стороне API — отдельная история (может «залипать» и матчить лишнее), и это не
+про URL-кодирование. Ограничиваемся URL-специальными: `&` и пробел. `%`/`_`/`[`
+в текущем таске **не** проверяем — оставим на потенциальный T12/T14 или отдельный defect.
+
+## 6. Тесты в этой задаче
+
+Одна спека, 5 тестов. Все идут через фикстуру `contactsClient`, все проходят
+`expectMatchesSchema`, каждый тест независим и self-contained.
+
+## 7. План работ
+
+1. Создать `tests/contacts/get-list.spec.ts` по §5.
+2. Удалить `tests/contacts/.gitkeep`.
+3. `npm run lint` → чисто.
+4. `npx tsc --noEmit` → чисто.
+5. `npx playwright test tests/contacts/get-list.spec.ts` при поднятом API → зелёная.
+6. Отметить **T10** в плане.
+
+## 8. Verification (шаг 8 промпта, test-authoring)
+
+- `npm run lint` → 0 ошибок.
+- `npx tsc --noEmit` → 0 ошибок.
+- `npx playwright test tests/contacts/get-list.spec.ts` — все 5 тестов зелёные.
+- `dotnet build src/AddressBook.sln` → без новых предупреждений.
+
+## 9. Out of scope / follow-ups
+
+- SQL-LIKE спец-символы (`%`, `_`, `[`) — не в этой задаче.
+- Пагинация / сортировка — API её сейчас не предоставляет.
+- README `src/ApiTests` — T17 / #71.
+- Миграция T6/T7/T8/T9-спек на фикстуры — не сюда.

--- a/src/ApiTests/tests/contacts/get-list.spec.ts
+++ b/src/ApiTests/tests/contacts/get-list.spec.ts
@@ -1,0 +1,95 @@
+import { StatusCodes } from 'http-status-codes';
+import { newTestToken } from '../../src/data/tokens.js';
+import { expect, test } from '../../src/fixtures/api.fixtures.js';
+import { getFilteredContactsResponseSchema } from '../../src/schemas/contact.schema.js';
+import { expectMatchesSchema } from '../../src/utils/assertions.js';
+
+test.describe('GET /api/Contacts — list', () => {
+  test('returns 200 with valid schema; TotalRows === Rows.length; includes the created contact', async ({
+    contactsClient,
+    contactFactory,
+  }) => {
+    const created = await contactsClient.create(contactFactory.validContact());
+    expect(created.status).toBe(StatusCodes.CREATED);
+
+    const response = await contactsClient.list();
+    expect(response.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(response.body, getFilteredContactsResponseSchema);
+    expect(parsed.rows).toHaveLength(parsed.totalRows);
+    expect(parsed.rows.some((row) => row.id === created.id)).toBe(true);
+  });
+});
+
+test.describe('GET /api/Contacts?search — search', () => {
+  test('by a unique local token returns exactly the created contacts', async ({
+    contactsClient,
+    contactFactory,
+  }) => {
+    const token = newTestToken();
+    const a = await contactsClient.create(contactFactory.validContact({ firstName: `A-${token}` }));
+    const b = await contactsClient.create(contactFactory.validContact({ firstName: `B-${token}` }));
+    expect(a.status).toBe(StatusCodes.CREATED);
+    expect(b.status).toBe(StatusCodes.CREATED);
+
+    const response = await contactsClient.list(token);
+    expect(response.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(response.body, getFilteredContactsResponseSchema);
+    expect(parsed.totalRows).toBe(2);
+    expect(parsed.rows).toHaveLength(2);
+    const foundIds = parsed.rows.map((row) => row.id).sort((x, y) => x - y);
+    const expectedIds = [a.id!, b.id!].sort((x, y) => x - y);
+    expect(foundIds).toEqual(expectedIds);
+  });
+
+  test('by an unknown token returns an empty result', async ({ contactsClient }) => {
+    // Freshly generated token never used in any create() call — cannot match anything.
+    const unknown = newTestToken();
+
+    const response = await contactsClient.list(unknown);
+    expect(response.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(response.body, getFilteredContactsResponseSchema);
+    expect(parsed.totalRows).toBe(0);
+    expect(parsed.rows).toHaveLength(0);
+  });
+
+  test('with an ampersand is URL-encoded correctly and finds the marker contact', async ({
+    contactsClient,
+    contactFactory,
+  }) => {
+    const marker = `Q&A-${newTestToken()}`;
+    const created = await contactsClient.create(
+      contactFactory.validContact({ firstName: marker }),
+    );
+    expect(created.status).toBe(StatusCodes.CREATED);
+
+    const response = await contactsClient.list(marker);
+    expect(response.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(response.body, getFilteredContactsResponseSchema);
+    expect(parsed.totalRows).toBe(1);
+    expect(parsed.rows[0].id).toBe(created.id);
+    expect(parsed.rows[0].firstName).toBe(marker);
+  });
+
+  test('with spaces is URL-encoded correctly and finds the marker contact', async ({
+    contactsClient,
+    contactFactory,
+  }) => {
+    const marker = `Hi There ${newTestToken()}`;
+    const created = await contactsClient.create(
+      contactFactory.validContact({ firstName: marker }),
+    );
+    expect(created.status).toBe(StatusCodes.CREATED);
+
+    const response = await contactsClient.list(marker);
+    expect(response.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(response.body, getFilteredContactsResponseSchema);
+    expect(parsed.totalRows).toBe(1);
+    expect(parsed.rows[0].id).toBe(created.id);
+    expect(parsed.rows[0].firstName).toBe(marker);
+  });
+});


### PR DESCRIPTION
Closes #65.

## What this change does

First real endpoint spec — task **T10** of [`docs/tasks/api-tests-framework-plan.md`](../blob/65-apitests-get-list/docs/tasks/api-tests-framework-plan.md) and the start of Phase 2. Covers `GET /api/Contacts` and its `?search=` variants using every framework piece from T4–T9.

- `src/ApiTests/tests/contacts/get-list.spec.ts` — 5 tests: list-response invariant (`Rows.length === TotalRows`, includes the created id); search by a unique local token → exactly the created ids; search by a fresh token → empty; URL encoding of `&` (`%26`); URL encoding of a space (`%20`).

Full acceptance table and file list are on the issue: askrinnik/AddressBook2025#65.

## Non-obvious decisions

- **Seed independence via `Rows.length === TotalRows`.** The only assertion on the full list is the response's own invariant; every other assertion pins ids to contacts this test created. That way seed data can grow or shrink without touching the spec.
- **`newTestToken()` as the "guaranteed unknown" search term.** Newly generated per call, so no `create()` anywhere ever used this value — the empty-result case doesn't rely on magic strings or a specific database state.
- **Encoding is proven through round-trip.** The spec creates a contact with the exact `firstName` (e.g. `"Q&A-<token>"` or `"Hi There <token>"`), lets the client URL-encode the search term, and asserts the API returns exactly that contact. If `&` weren't encoded, the API would receive an empty `search` and the assertion would fail.
- **No manual `delete` calls.** All creations go through the T8 `contactsClient` fixture, whose teardown removes every registered id best-effort. Parallel workers can't cross-pollute because their `RUN_TOKEN` prefixes differ.
- **SQL-LIKE special chars (`%`, `_`, `[`) intentionally not tested here.** That's separate behaviour of the SQL layer (they'd match unintendedly), not URL-encoding, and belongs to a follow-up defect if we decide the current behaviour is wrong.

## Verification

- `npm run lint` in `src/ApiTests` — clean.
- `npx tsc --noEmit` in `src/ApiTests` — clean.
- `npx playwright test tests/contacts/get-list.spec.ts` against the local API — 5/5 passed with 5 workers.
- `dotnet build src/AddressBook.sln` — succeeded with no new warnings (no C# code was touched).
