### PR TITLE
#67 [ApiTests][T11] tests/contacts/get-by-id.spec.ts

### DIFF
--- a/docs/tasks/api-tests-framework-plan.md
+++ b/docs/tasks/api-tests-framework-plan.md
@@ -104,7 +104,7 @@ src/ApiTests/
 ### Фаза 2 — Тесты
 
 - [x] **T10** ([#65](https://github.com/askrinnik/AddressBook2025/issues/65)) `tests/contacts/get-list.spec.ts` — поиск, пустой результат, кодирование query, независимость от seed.
-- [ ] **T11** ([#67](https://github.com/askrinnik/AddressBook2025/issues/67)) `tests/contacts/get-by-id.spec.ts` — созданный контакт, `404`, нечисловой id → `404`.
+- [x] **T11** ([#67](https://github.com/askrinnik/AddressBook2025/issues/67)) `tests/contacts/get-by-id.spec.ts` — созданный контакт, `404`, нечисловой id → `404`.
 - [ ] **T12** ([#69](https://github.com/askrinnik/AddressBook2025/issues/69)) `tests/contacts/create.spec.ts` — валидный с/без birthday, границы 30/31, пусто, баг триммінга `"   "`, будущая дата → `400` + problem-details, «сегодня» → OK.
 - [ ] **T13** ([#73](https://github.com/askrinnik/AddressBook2025/issues/73)) `tests/contacts/update.spec.ts` — **PUT (новое покрытие)**: полное/частичное обновление, `404`, валидация `400`, границы.
 - [ ] **T14** ([#68](https://github.com/askrinnik/AddressBook2025/issues/68)) `tests/contacts/delete.spec.ts` — удаление созданного (`204`) → затем `404`, удаление неизвестного → `404`.

--- a/docs/tasks/issue-67-apitests-get-by-id.md
+++ b/docs/tasks/issue-67-apitests-get-by-id.md
@@ -1,0 +1,112 @@
+# Issue #67 — `[ApiTests][T11]` `tests/contacts/get-by-id.spec.ts`
+
+**Type:** test-authoring (метки `api`, `testing`) — задача **T11** из плана
+[`api-tests-framework-plan.md`](./api-tests-framework-plan.md).
+**Scope:** только `src/ApiTests/tests/contacts/get-by-id.spec.ts`. Никакого продакшн-кода,
+никаких правок `src/AutoTests` и никаких существующих спек.
+**Зависимости:** T4 (`contactModelSchema`), T5 (`ContactsClient.getById` — принимает
+`number | string`), T7 (`ContactFactory.validContact`), T8 (`api.fixtures.ts` — авто-очистка),
+T9 (`expectMatchesSchema`).
+
+## 1. Требование (из issue)
+
+Тесты `GET /api/Contacts/{id}`:
+
+- Получить созданный контакт по id — `200`, поля совпадают с отправленными.
+- Несуществующий id (свежесозданный + удалённый) — `404`.
+- Нечисловой id (`abc`) — `404` (route constraint `{id:int}`).
+
+Критерии из issue:
+
+- Self-contained данные (без хардкода `id = 1`).
+- Проверка ответа против zod-схемы `ContactModel`.
+
+## 2. Факты об API (проверено по коду `AddressBook.Api`)
+
+- **Контроллер** [`ContactsController.GetById`](../../src/AddressBook.Api/Controllers/ContactsController.cs)
+  — `HttpGet("{id:int}")`, при `null` из handler-а `NotFound()`, иначе `Ok(ContactModel)`.
+- Route constraint `{id:int}` — C# `int` (Int32). При нечисловом id или переполнении
+  (`> Int32.MaxValue`) MVC-роутинг **не** матчит маршрут — возвращает `404` до входа
+  в контроллер (тот же путь мы уже эксплуатировали в teardown фикстуры T8).
+- **Handler**
+  [`GetContactByIdQueryHandler`](../../src/AddressBook.Api/Application/GetContactByIdQueryHandler.cs)
+  использует `IRetrieve<ContactId, Contact>.TryRetrieveAsync` — возвращает `null` при
+  отсутствии → контроллер отдаёт `404`. Никакого problem-details тела на 404 не
+  формируется — просто пустой ответ (`NotFound()`).
+- **Ответ 200** содержит `ContactModel { id, firstName, lastName, birthday }` в camelCase —
+  форма зафиксирована в T4-схеме `contactModelSchema`.
+
+## 3. Acceptance criteria
+
+| # | Критерий | Как проверим |
+|---|----------|--------------|
+| AC1 | `GET /api/Contacts/{id}` для созданного контакта — статус `200`, тело валидируется `contactModelSchema` и поля (`id`, `firstName`, `lastName`, `birthday`) совпадают с отправленными. | Тест `returns 200 with the created contact's fields`. |
+| AC2 | `GET /api/Contacts/{id}` для удалённого контакта — статус `404`. | Тест `returns 404 for a freshly deleted contact`. Создание и удаление — через фикстуру. |
+| AC3 | `GET /api/Contacts/abc` (нечисловой) — статус `404` (сработал route constraint). | Тест `returns 404 for a non-numeric id`. |
+| AC4 | `GET /api/Contacts/{overflowInt32}` — статус `404` (route constraint не матчит). Дополнительный boundary — покрывает поведение, на которое опирается teardown T8. | Тест `returns 404 for an id that overflows int32`. |
+| AC5 | Ни один тест не хардкодит `id = 1` / `id = 2` и не полагается на seed-данные. | Code review + сам факт: все положительные и делеты идут через созданные фабрикой контакты. |
+| AC6 | Все создания через `contactsClient.create` (фикстура T8), никаких прямых `delete` кроме той, что часть тест-сценария. Оставшиеся созданные контакты автоочистятся teardown-ом фикстуры. | Code review + прогон. |
+| AC7 | `npm run lint` + `npx tsc --noEmit` чисто. | Прогон в шаге 8. |
+| AC8 | Чек-бокс **T11** в [`api-tests-framework-plan.md`](./api-tests-framework-plan.md) переведён в `[x]`. | Diff файла плана. |
+
+## 4. Затрагиваемые файлы
+
+| Файл | Изменение |
+|------|-----------|
+| `src/ApiTests/tests/contacts/get-by-id.spec.ts` | **Новый** — единственный спек T11. |
+| `docs/tasks/api-tests-framework-plan.md` | Отметить **T11** как `[x]`. |
+
+## 5. Дизайн спеки
+
+Импорты — все через фикстуры и хелперы предыдущих задач. Одна `describe`, четыре теста:
+
+```
+test.describe('GET /api/Contacts/{id}', () => {
+  1. returns 200 with the created contact's fields (happy path, schema, all fields)
+  2. returns 404 for a freshly deleted contact
+  3. returns 404 for a non-numeric id (route constraint)
+  4. returns 404 for an id that overflows int32 (route constraint)
+})
+```
+
+Ключевые решения:
+
+- **`Number.MAX_SAFE_INTEGER` — «переполнение int32».** `> 2^31-1`, гарантированно проваливает
+  `{id:int}` → `404`. Тот же способ уже эксплуатировался в T8 (тест устойчивости teardown).
+- **`getById('abc')` — нечисловой id.** `ContactsClient.getById` принимает `number | string` и
+  прогоняет через `encodeURIComponent(String(id))` — URL безопасен, до контроллера доедет строка,
+  route не сматчится → `404`.
+- **Тело 404 не проверяем.** ASP.NET `NotFound()` возвращает пустой ответ; фиксируем только
+  статус — это ровно то, что спрашивает issue.
+- **Для happy path — точное сравнение всех полей.** `payload.firstName === parsed.firstName`,
+  `payload.lastName === parsed.lastName`, `payload.birthday === parsed.birthday`. Так подтверждаем
+  round-trip запись → чтение без потерь. `id` берётся из `Location` (парсит `contactsClient.create`).
+- **Никаких прямых `delete` кроме теста-«удалённый контакт».** Всё остальное чистится
+  teardown-ом фикстуры.
+
+## 6. Тесты в этой задаче
+
+Одна спека, 4 теста. Все идут через фикстуру `contactsClient`, все проверяются схемой
+там, где имеет смысл (только на `200`).
+
+## 7. План работ
+
+1. Создать `tests/contacts/get-by-id.spec.ts` по §5.
+2. `npm run lint` → чисто.
+3. `npx tsc --noEmit` → чисто.
+4. `npx playwright test tests/contacts/get-by-id.spec.ts` при поднятом API → зелёная.
+5. Отметить **T11** в плане.
+
+## 8. Verification (шаг 8 промпта, test-authoring)
+
+- `npm run lint` → 0 ошибок.
+- `npx tsc --noEmit` → 0 ошибок.
+- `npx playwright test tests/contacts/get-by-id.spec.ts` — все 4 теста зелёные.
+- `dotnet build src/AddressBook.sln` → без новых предупреждений.
+
+## 9. Out of scope / follow-ups
+
+- Отрицательный `id` (`-1`) — валидный по route (`int` знаковый), просто нет в БД → тот же
+  `404`, что и в тесте 2. Отдельно не тестируем — дублирует существующий кейс.
+- Тело 404 (пустое сейчас, но ASP.NET может настроить `Problem()`) — не в скоупе issue.
+- README `src/ApiTests` — T17 / #71.

--- a/src/ApiTests/tests/contacts/get-by-id.spec.ts
+++ b/src/ApiTests/tests/contacts/get-by-id.spec.ts
@@ -1,0 +1,48 @@
+import { StatusCodes } from 'http-status-codes';
+import { expect, test } from '../../src/fixtures/api.fixtures.js';
+import { contactModelSchema } from '../../src/schemas/contact.schema.js';
+import { expectMatchesSchema } from '../../src/utils/assertions.js';
+
+test.describe('GET /api/Contacts/{id}', () => {
+  test("returns 200 with the created contact's fields", async ({
+    contactsClient,
+    contactFactory,
+  }) => {
+    const payload = contactFactory.validContact();
+    const created = await contactsClient.create(payload);
+    expect(created.status).toBe(StatusCodes.CREATED);
+    expect(created.id).toBeGreaterThan(0);
+
+    const response = await contactsClient.getById(created.id!);
+    expect(response.status).toBe(StatusCodes.OK);
+
+    const parsed = expectMatchesSchema(response.body, contactModelSchema);
+    expect(parsed.id).toBe(created.id);
+    expect(parsed.firstName).toBe(payload.firstName);
+    expect(parsed.lastName).toBe(payload.lastName);
+    expect(parsed.birthday).toBe(payload.birthday);
+  });
+
+  test('returns 404 for a freshly deleted contact', async ({ contactsClient, contactFactory }) => {
+    const created = await contactsClient.create(contactFactory.validContact());
+    expect(created.status).toBe(StatusCodes.CREATED);
+
+    const deleted = await contactsClient.delete(created.id!);
+    expect(deleted.status).toBe(StatusCodes.NO_CONTENT);
+
+    const response = await contactsClient.getById(created.id!);
+    expect(response.status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  test('returns 404 for a non-numeric id (route constraint)', async ({ contactsClient }) => {
+    const response = await contactsClient.getById('abc');
+    expect(response.status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  test('returns 404 for an id that overflows int32 (route constraint)', async ({
+    contactsClient,
+  }) => {
+    const response = await contactsClient.getById(Number.MAX_SAFE_INTEGER);
+    expect(response.status).toBe(StatusCodes.NOT_FOUND);
+  });
+});


### PR DESCRIPTION
Closes #67.

## What this change does

Task **T11** of [`docs/tasks/api-tests-framework-plan.md`](../blob/67-apitests-get-by-id/docs/tasks/api-tests-framework-plan.md): the `GET /api/Contacts/{id}` endpoint spec.

- `src/ApiTests/tests/contacts/get-by-id.spec.ts` — 4 tests:
  - Happy path: create → fetch by id → `200`, schema-valid `ContactModel`, all fields match the payload.
  - Freshly deleted contact → `404`.
  - Non-numeric id (`'abc'`) → `404` from the `{id:int}` route constraint.
  - `Number.MAX_SAFE_INTEGER` (int32 overflow) → `404` from the same route constraint.

Full acceptance table and file list are on the issue: askrinnik/AddressBook2025#67.

## Non-obvious decisions

- **Two negative-id cases, not one.** The issue mentions `abc` explicitly; the int32-overflow case is added as a natural companion boundary and documents the exact behaviour that T8's teardown resilience test already relies on.
- **404 assertions check status only.** `NotFound()` in ASP.NET returns an empty body. Verifying a specific problem-details shape would attach coverage to whatever ASP.NET happens to serialise today; the issue asks for the status code, and that's what we assert. Problem-details coverage remains with T12 (`create.spec.ts`), where the API actually emits it.
- **`getById(number | string)` was already fit.** The T5 client accepts both and URL-encodes via `encodeURIComponent(String(id))` — no client change needed for `'abc'` or a huge number.
- **All ids come from `create()` or are synthesised locally.** Nothing references `id = 1` / `id = 2`; the spec is stable regardless of seed data or other tests running in parallel.

## Verification

- `npm run lint` in `src/ApiTests` — clean.
- `npx tsc --noEmit` in `src/ApiTests` — clean.
- `npx playwright test tests/contacts/get-by-id.spec.ts` against the local API — 4/4 passed with 4 workers.
- `dotnet build src/AddressBook.sln` — succeeded with no new warnings (no C# code was touched).
